### PR TITLE
v0.06

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,9 @@ Navigate to [`collatz.js`](./collatz.js) and click on `Raw`. You will be
 delivered to this theory's raw code. Copy the page's URL.
 
 Then, access the custom theory panel within the game (unlocked after finishing
-the Convergence Test) then enter the picking menu. Press the `+` symbol and
+T9, the last theory) then enter the picking menu. Press the `+` symbol and
 paste the URL in.
 
 ## Screenshots
 
 ![ss0](screenshots/09.jpg 'Collatz Conjecture')
-

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,5 @@
 # Collatz Conjecture
 
-## In testing
-
-- v0.06
-
 ## In consideration
 
 - Ask Gilles:
@@ -16,19 +12,6 @@
     - Rescale marathon achievement
   - [ ] Move 3rd ms to 176 but move extra increments forward
   - [ ] Change step length of penalty to 6
-  - [x] History shows number of turns between nudges
-- [x] Determine metrics for:
-  - [x] History book icon (24)
-  - [x] History menu buttons (44)
-  - [x] History pub labels (24)
-- [x] Rename c1c2 to q1q2 for distinction from c
-- [x] Emergency upgrade that opens after c hits cap
-  - Only increments, no decrements (does it benefit negative runs?)
-  - [x] Deducts 2+ levels of c every time it's bought
-  - Can make players more impatient
-  - [x] Make it a perma upgrade
-- [x] Nerf exp to 4.72 or 4.92? Also remove division
-- [x] Buff c2 base to ~~3.01~~ 3? Compensate by nerfing pub exp
 - From d4N:
   - Make a Collatz Conjurator/Conjoiner that makes decision trees or sequences
   -  Make runs less monotonous
@@ -42,6 +25,22 @@
     - Solves the problem of players being confused by c level
     - But also trivialises the game by allowing you to farm massive amounts of
     levels
+
+## 0.06
+
+- [x] History shows number of turns between nudges
+- [x] Determine metrics for:
+  - [x] History book icon (24)
+  - [x] History menu buttons (44)
+  - [x] History pub labels (24)
+- [x] Rename c1c2 to q1q2 for distinction from c
+- [x] Emergency upgrade that opens after c hits cap
+  - Only increments, no decrements (does it benefit negative runs?)
+  - [x] Deducts 2+ levels of c every time it's bought
+  - Can make players more impatient
+  - [x] Make it a perma upgrade
+- [x] Nerf exp to 4.72 or 4.92? Also remove division
+- [x] Buff c2 base to ~~3.01~~ 3? Compensate by nerfing pub exp
 
 ## 0.05
 

--- a/TODO.md
+++ b/TODO.md
@@ -6,8 +6,9 @@
 
 ## In consideration
 
-- [ ] Nerf initial pub mult
-  - Better to defer this to when XLII comes online to sim
+- Better to defer these to when XLII comes online to sim
+  - [ ] Nerf initial pub mult
+  - [ ] Nerf final level cap to 64
 - [x] History shows number of turns between nudges
 - [x] Rename c1c2 to q1q2 for distinction from c
 - [x] Emergency upgrade that opens after c hits cap

--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,8 @@
 
 ## In consideration
 
+- [ ] Nerf initial pub mult
+  - Better to defer this to when XLII comes online to sim
 - [x] History shows number of turns between nudges
 - [x] Rename c1c2 to q1q2 for distinction from c
 - [x] Emergency upgrade that opens after c hits cap

--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,7 @@
 
 ## In consideration
 
+- [ ] History shows number of turns between nudges
 - [x] Emergency upgrade that opens after c hits cap
   - Only increments, no decrements (does it benefit negative runs?)
   - [ ] Deducts 2 levels of c every time it's bought

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,7 @@
 
 ## In consideration
 
-- [ ] History shows number of turns between nudges
+- [x] History shows number of turns between nudges
 - [x] Rename c1c2 to q1q2 for distinction from c
 - [x] Emergency upgrade that opens after c hits cap
   - Only increments, no decrements (does it benefit negative runs?)

--- a/TODO.md
+++ b/TODO.md
@@ -9,11 +9,18 @@
 - Ask Gilles:
   - [ ] Make a bonus levels function like perma levels from stars
 - Better to defer these to when XLII comes online to sim
-  - [ ] Nerf initial pub mult
-  - [ ] Nerf level caps to 24/36/48/64 if the game's still too easy
+  - [ ] Nerf initial pub mult?
+  - [ ] From 0 to e44 is the tutorial. The players must both learn about running
+  - quickly (early) and running deep (before e44).
+  - [ ] Nerf level caps to 24/36/48/64
     - Rescale marathon achievement
   - [ ] Move 3rd ms to 176 but move extra increments forward
-- [x] History shows number of turns between nudges
+  - [ ] Change step length of penalty to 6
+  - [x] History shows number of turns between nudges
+- [x] Determine metrics for:
+  - [x] History book icon (24)
+  - [x] History menu buttons (44)
+  - [x] History pub labels (24)
 - [x] Rename c1c2 to q1q2 for distinction from c
 - [x] Emergency upgrade that opens after c hits cap
   - Only increments, no decrements (does it benefit negative runs?)
@@ -21,10 +28,10 @@
   - Can make players more impatient
   - [x] Make it a perma upgrade
 - [x] Nerf exp to 4.72 or 4.92? Also remove division
+- [x] Buff c2 base to ~~3.01~~ 3? Compensate by nerfing pub exp
 - From d4N:
   - Make a Collatz Conjurator/Conjoiner that makes decision trees or sequences
-  - Make runs less monotonous
-- [x] Buff c2 base to ~~3.01~~ 3? Compensate by nerfing pub exp
+  -  Make runs less monotonous
 - Make pub exponent go down gradually like `y=(10/log(x+1)+6.22)`?
   - This is to make early game more lenient
   - Disproven: early game is very normal at 5.22

--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,7 @@
 
 ## In consideration
 
+- [ ] Rename c1c2 to q1q2 for distinction from c
 - [ ] History shows number of turns between nudges
 - [x] Emergency upgrade that opens after c hits cap
   - Only increments, no decrements (does it benefit negative runs?)

--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,8 @@
   - [ ] Make a bonus levels function like perma levels from stars
 - Better to defer these to when XLII comes online to sim
   - [ ] Nerf initial pub mult
-  - [ ] Nerf final level cap to 64
+  - [ ] Nerf level caps to 24/36/48/64 if the game's still too easy
+    - Rescale marathon achievement
   - [ ] Move 3rd ms to 176 but move extra increments forward
 - [x] History shows number of turns between nudges
 - [x] Rename c1c2 to q1q2 for distinction from c

--- a/TODO.md
+++ b/TODO.md
@@ -6,11 +6,12 @@
 
 ## In consideration
 
-- [ ] Emergency upgrade that opens after c hits cap
-  - Only increments, no decrements
-  - Deducts 2 levels of c every time it's bought
-  - But, makes players more impatient
-- [ ] Nerf exp to 4.72 or 4.92? Also remove division
+- [x] Emergency upgrade that opens after c hits cap
+  - Only increments, no decrements (does it benefit negative runs?)
+  - [ ] Deducts 2 levels of c every time it's bought
+    - Currently only deducts 1 for leniency
+  - Can make players more impatient
+- [x] Nerf exp to 4.72 or 4.92? Also remove division
 - From d4N:
   - Make a Collatz Conjurator/Conjoiner that makes decision trees or sequences
 - [ ] Buff c2 base to 3.01? Compensate by nerfing pub exp

--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,7 @@
 - From d4N:
   - Make a Collatz Conjurator/Conjoiner that makes decision trees or sequences
   - Make runs less monotonous
-- [ ] Buff c2 base to 3.01? Compensate by nerfing pub exp
+- [x] Buff c2 base to ~~3.01~~ 3? Compensate by nerfing pub exp
 - Make pub exponent go down gradually like `y=(10/log(x+1)+6.22)`?
   - This is to make early game more lenient
   - Disproven: early game is very normal at 5.22

--- a/TODO.md
+++ b/TODO.md
@@ -6,8 +6,8 @@
 
 ## In consideration
 
-- [ ] Rename c1c2 to q1q2 for distinction from c
 - [ ] History shows number of turns between nudges
+- [x] Rename c1c2 to q1q2 for distinction from c
 - [x] Emergency upgrade that opens after c hits cap
   - Only increments, no decrements (does it benefit negative runs?)
   - [x] Deducts 2+ levels of c every time it's bought

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 ## In testing
 
-- v0.05
+- v0.06
 
 ## In consideration
 

--- a/TODO.md
+++ b/TODO.md
@@ -6,12 +6,19 @@
 
 ## In consideration
 
+- [ ] Emergency upgrade that opens after c hits cap
+  - Only increments, no decrements
+  - Deducts 2 levels of c every time it's bought
+  - But, makes players more impatient
+- [ ] Nerf exp to 4.72 or 4.92? Also remove division
+- From d4N:
+  - Make a Collatz Conjurator/Conjoiner that makes decision trees or sequences
 - [ ] Buff c2 base to 3.01? Compensate by nerfing pub exp
 - Make pub exponent go down gradually like `y=(10/log(x+1)+6.22)`?
   - This is to make early game more lenient
   - Disproven: early game is very normal at 5.22
-- [ ] Counter: make pub exponent go up gradually to 5.22
-  - This is to make early game players not delusional about pub multipliers
+  - Counter: make pub exponent go up gradually to 5.22
+    - This is to make early game players not delusional about pub multipliers
 - From pietro:
   - Save some levels for the next pub if not used up in current one
     - Solves the problem of players being confused by c level

--- a/TODO.md
+++ b/TODO.md
@@ -6,9 +6,12 @@
 
 ## In consideration
 
+- Ask Gilles:
+  - [ ] Make a bonus levels function like perma levels from stars
 - Better to defer these to when XLII comes online to sim
   - [ ] Nerf initial pub mult
   - [ ] Nerf final level cap to 64
+  - [ ] Move 3rd ms to 176 but move extra increments forward
 - [x] History shows number of turns between nudges
 - [x] Rename c1c2 to q1q2 for distinction from c
 - [x] Emergency upgrade that opens after c hits cap

--- a/TODO.md
+++ b/TODO.md
@@ -15,6 +15,7 @@
 - [x] Nerf exp to 4.72 or 4.92? Also remove division
 - From d4N:
   - Make a Collatz Conjurator/Conjoiner that makes decision trees or sequences
+  - Make runs less monotonous
 - [ ] Buff c2 base to 3.01? Compensate by nerfing pub exp
 - Make pub exponent go down gradually like `y=(10/log(x+1)+6.22)`?
   - This is to make early game more lenient

--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,7 @@
 
 ## In consideration
 
+- [ ] Buff c2 base to 3.01? Compensate by nerfing pub exp
 - Make pub exponent go down gradually like `y=(10/log(x+1)+6.22)`?
   - This is to make early game more lenient
   - Disproven: early game is very normal at 5.22

--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,7 @@
   - Only increments, no decrements (does it benefit negative runs?)
   - [x] Deducts 2+ levels of c every time it's bought
   - Can make players more impatient
-  - [ ] Make it a perma upgrade
+  - [x] Make it a perma upgrade
 - [x] Nerf exp to 4.72 or 4.92? Also remove division
 - From d4N:
   - Make a Collatz Conjurator/Conjoiner that makes decision trees or sequences

--- a/TODO.md
+++ b/TODO.md
@@ -9,9 +9,9 @@
 - [ ] History shows number of turns between nudges
 - [x] Emergency upgrade that opens after c hits cap
   - Only increments, no decrements (does it benefit negative runs?)
-  - [ ] Deducts 2 levels of c every time it's bought
-    - Currently only deducts 1 for leniency
+  - [x] Deducts 2+ levels of c every time it's bought
   - Can make players more impatient
+  - [ ] Make it a perma upgrade
 - [x] Nerf exp to 4.72 or 4.92? Also remove division
 - From d4N:
   - Make a Collatz Conjurator/Conjoiner that makes decision trees or sequences

--- a/collatz.js
+++ b/collatz.js
@@ -1,6 +1,5 @@
 import { BigNumber } from '../api/BigNumber';
-import { CompositeCost, ExponentialCost, FirstFreeCost, FreeCost, LinearCost } from
-'../api/Costs';
+import { CompositeCost, ExponentialCost, FirstFreeCost, FreeCost, LinearCost } from '../api/Costs';
 import { Localization } from '../api/Localization';
 import { Theme } from '../api/Settings';
 import { theory } from '../api/Theory';
@@ -327,7 +326,7 @@ const c1Cost = new FirstFreeCost(new ExponentialCost(1, 3.01));
 const getc1 = (level) => Utils.getStepwisePowerSum(level + Math.floor(
 c1BorrowMs.level * incrementc.level / borrowFactor), 2, 5, 1);
 
-const c1ExpInc = 0.07;
+const c1ExpInc = 0.03;
 const c1ExpMaxLevel = 4;
 const getc1Exponent = (level) => 1 + c1ExpInc * level;
 

--- a/collatz.js
+++ b/collatz.js
@@ -59,6 +59,7 @@ let writeHistory = true;
 let historyNumMode = 0;
 let historyIdxMode = 0;
 let reachedFirstPub = false;
+let marathonBadge = false;
 
 let bigNumArray = (array) => array.map(x => BigNumber.from(x));
 
@@ -78,7 +79,7 @@ const q1ExpMaxLevel = 4;
 const getq1Exponent = (level) => 1 + q1ExpInc * level;
 
 const q2Cost = new ExponentialCost(2.2e7, 11);
-const getq2 = (level) => BigNumber.THREE.pow(level);
+const getq2 = (level) => BigNumber.THREE.pow(level) + (marathonBadge ? 1 : 0);
 
 const permaCosts = bigNumArray(['1e12', '1e22', '1e31', '1e54', '1e160']);
 const milestoneCost = new CompositeCost(2, new LinearCost(4.4, 4.4),
@@ -158,7 +159,7 @@ It's thesis time.`,
         achNegativeTitle: 'Shrouded by Fog',
         achNegativeDesc: `Publish with an odd level of c and go negative.`,
         achMarathonTitle: 'Annual Lothar-athon',
-        achMarathonDesc: 'Reach a c value of ±1e60.',
+        achMarathonDesc: 'Reach a c value of ±1e60.\n\nReward: +1 to q2.',
         achSixNineTitle: 'I\'m proud of you.',
         achSixNineDesc: 'Reach a c value of 69.',
 
@@ -483,7 +484,7 @@ var init = () =>
     Standard doubling upgrade.
     */
     {
-        let getDesc = (level) => `q_2=3^{${level}}`;
+        let getDesc = (level) => `q_2=3^{${level}}${marathonBadge ? '+1' : ''}`;
         let getInfo = (level) => `q_2=${getq2(level).toString(0)}`;
         q2 = theory.createUpgrade(2, currency, q2Cost);
         q2.getDescription = (_) => Utils.getMath(getDesc(q2.level));
@@ -644,6 +645,7 @@ var updateAvailability = () =>
         historyLabel.isVisible = true;
         reachedFirstPub = true;
     }
+    marathonBadge = theory.achievements[1].isUnlocked;
     incrementc.isAvailable = extraIncPerma.level > 0 &&
     nudgec.level == nudgec.maxLevel;
 }

--- a/collatz.js
+++ b/collatz.js
@@ -163,8 +163,8 @@ It's thesis time.`,
         achSixNineDesc: 'Reach a c value of 69.',
 
         btnClose: 'Close',
-        btnIndexingMode: ['Indexing: Turns (t)', 'Indexing: Levels'],
-        btnNotationMode: ['Disp.: Digits', 'Disp.: Scientific'],
+        btnIndexingMode: ['Indexing: Turns', 'Indexing: Levels'],
+        btnNotationMode: ['Notation: Digits', 'Notation: Scientific'],
         btnBaseMode: ['Base: 10', 'Base: 2'],
         errorInvalidNumMode: 'Invalid number mode',
         errorBinExpLimit: 'Too big',
@@ -825,21 +825,23 @@ let createHistoryMenu = () =>
     ({
         row: 2,
         column: 0,
+        text: getSequence(history, historyNumMode, historyIdxMode),
+        margin: new Thickness(0, 0, 3, 0),
         horizontalOptions: LayoutOptions.CENTER,
-        text: getSequence(history, historyNumMode, historyIdxMode)
     });
     let lastPubHistory = ui.createLatexLabel
     ({
         row: 2,
         column: 1,
+        text: getSequence(lastHistory, historyNumMode, historyIdxMode),
+        margin: new Thickness(3, 0, 0, 0),
         horizontalOptions: LayoutOptions.CENTER,
-        text: getSequence(lastHistory, historyNumMode, historyIdxMode)
     });
     let historyGrid = ui.createGrid
     ({
         rowDefinitions: ['24', '13', 'auto'],
         columnDefinitions: ['1*', '1*'],
-        // columnSpacing: 8,
+        columnSpacing: 0,
         children:
         [
             ui.createLatexLabel
@@ -886,7 +888,7 @@ let createHistoryMenu = () =>
                 ui.createGrid
                 ({
                     rowDefinitions: [44],
-                    columnDefinitions: ['3*', '2*', '3*'],
+                    columnDefinitions: ['8*', '5*', '9*'],
                     columnSpacing: 8,
                     children:
                     [

--- a/collatz.js
+++ b/collatz.js
@@ -580,6 +580,9 @@ var updateAvailability = () =>
 
 var tick = (elapsedTime, multiplier) =>
 {
+    if(elapsedTime > 0.1)
+        log(`Long tick: ${elapsedTime.toFixed(3)}s`);
+
     if(pausec.level % 2 == 0)
     {
         ++time;
@@ -602,7 +605,6 @@ var tick = (elapsedTime, multiplier) =>
     }
 
     let dt = BigNumber.from(elapsedTime * multiplier);
-    if(dt > 0.2)log(dt)
     let vc1 = getc1(c1.level).pow(getc1Exponent(c1ExpMs.level));
     let vc2 = getc2(c2.level);
     let bonus = theory.publicationMultiplier;

--- a/collatz.js
+++ b/collatz.js
@@ -123,7 +123,7 @@ const locStrings =
 
         permaPause: '\\text{{the ability to freeze }}c',
         permaIncrement: '\\text{{extra increments of }}c',
-        permaIncrementInfo: `\\text{{Does not alternate; incurs penalty on}}c
+        permaIncrementInfo: `\\text{{Does not alternate; incurs penalty on }}c
         \\text{{\'s level}}`,
         permaPreserveDesc: '\\text{Preserve }c\\text{ after publishing}',
         permaPreserveInfo: '\\text{Preserves }c\\text{ after publishing}',
@@ -524,7 +524,7 @@ var init = () =>
         new ConstantCost(permaCosts[4]));
         extraIncPerma.description = Localization.getUpgradeUnlockDesc(getLoc(
         'permaIncrement'));
-        extraIncPerma.info = Utils.getMath('permaIncrementInfo');
+        extraIncPerma.info = Utils.getMath(getLoc('permaIncrementInfo'));
         extraIncPerma.bought = (_) => updateAvailability();
         extraIncPerma.maxLevel = 1;
     }

--- a/collatz.js
+++ b/collatz.js
@@ -67,8 +67,8 @@ let bigNumArray = (array) => array.map(x => BigNumber.from(x));
 
 const borrowFactor = 4;
 const q1Cost = new FirstFreeCost(new ExponentialCost(1, 3.01));
-const getIncrementPenalty = (level) => Utils.getStepwisePowerSum(level,
-2, 4, 0).toNumber();
+const getIncrementPenalty = (level) => Math.round(Utils.getStepwisePowerSum(
+level, 2, 4, 0).toNumber());
 const getq1BonusLevels = (bl, pl) => Math.max(Math.floor((bl * nudgec.level - 
 getIncrementPenalty(pl)) / borrowFactor), 0);
 const getq1 = (level) => Utils.getStepwisePowerSum(level + getq1BonusLevels(

--- a/collatz.js
+++ b/collatz.js
@@ -108,7 +108,7 @@ const locStrings =
 \\text{72 nudge levels}\\\\
 \\bullet \\text{ Pub formula~}\\\\ \\frac{{\\tau}^{5.22}}{31} \\rightarrow
 {\\tau}^{4.72}\\\\
-\\bullet \\text{ } c_1 \\text{ level ms~}\\\\
+\\bullet \\text{ } q_1 \\text{ level ms~}\\\\
 1/2 \\rightarrow 1/4,\\\\
 \\text{rounded down}\\\\
 \\bullet \\text{ Freeze cost~}\\\\ 1e66 \\rightarrow 1e54\\\\
@@ -119,7 +119,7 @@ const locStrings =
         \\end{{array}}`,
         historyInfo: 'Shows the last and current runs\' sequences',
         pausecDesc: ['\\text{Freeze }c', '\\text{Unfreeze }c'],
-        pausecInfo: '\\text{Freezes }c\\text{\'s value}',
+        pausecInfo: '\\text{Freezes }c\\text{ value}',
 
         permaPause: '\\text{{the ability to freeze }}c',
         permaIncrement: `\\text{{extra in/decrements for }}c`,
@@ -128,10 +128,10 @@ const locStrings =
         permaPreserveDesc: '\\text{Preserve }c\\text{ after publishing}',
         permaPreserveInfo: '\\text{Preserves }c\\text{ after publishing}',
 
-        c1Level: 'c_1\\text{{ level}}',
-        cLevel: '1/{{{0}}}\\text{{{{ of }}}}c\\text{{{{\'s level}}}}',
+        c1Level: 'q_1\\text{{ level}}',
+        cLevel: '1/{{{0}}}\\text{{{{ of }}}}c\\text{{{{ level}}}}',
         cLevelth: `1/{{{0}}}^\\text{{{{th}}}}\\text{{{{ of }}}}c
-        \\text{{{{\'s level}}}}`,
+        \\text{{{{ level}}}}`,
         cLevelCap: 'c\\text{{ level cap}}',
         cooldown: '\\text{{interval}}',
         cooldownInfo: 'Interval',
@@ -443,7 +443,7 @@ var init = () =>
         nudgec.isAutoBuyable = false;
         nudgec.maxLevel = cLevelCap[0];
     }
-    /* c1
+    /* q1 (c1 prior to 0.06)
     Most theories use a (2, 10) stepwise power, which I criticise to be too weak
     to be worth putting autobuy on. In Botched, a (3, 6) was used, and c1's cost
     there would align with c2 near perfectly at ~6 c1 upgrades per c2 upgrade.
@@ -451,11 +451,11 @@ var init = () =>
     more powerful.
     */
     {
-        let getDesc = (level) => `c_1=${getc1(level).toString(0)}`;
+        let getDesc = (level) => `q_1=${getc1(level).toString(0)}`;
         let getInfo = (level) =>
         {
             if(c1ExpMs.level > 0)
-                return `c_1^{${getc1Exponent(c1ExpMs.level)}}=
+                return `q_1^{${getc1Exponent(c1ExpMs.level)}}=
                 ${getc1(level).pow(getc1Exponent(c1ExpMs.level)).toString()}`;
 
             return getDesc(level);
@@ -465,12 +465,12 @@ var init = () =>
         c1.getInfo = (amount) => Utils.getMathTo(getInfo(c1.level),
         getInfo(c1.level + amount));
     }
-    /* c2
+    /* q2 (c2 prior to 0.06)
     Standard doubling upgrade.
     */
     {
-        let getDesc = (level) => `c_2=3^{${level}}`;
-        let getInfo = (level) => `c_2=${getc2(level).toString(0)}`;
+        let getDesc = (level) => `q_2=3^{${level}}`;
+        let getInfo = (level) => `q_2=${getc2(level).toString(0)}`;
         c2 = theory.createUpgrade(2, currency, c2Cost);
         c2.getDescription = (_) => Utils.getMath(getDesc(c2.level));
         c2.getInfo = (amount) => Utils.getMathTo(getInfo(c2.level),
@@ -600,9 +600,9 @@ var init = () =>
     */
     {
         c1ExpMs = theory.createMilestoneUpgrade(2, c1ExpMaxLevel);
-        c1ExpMs.description = Localization.getUpgradeIncCustomExpDesc('c_1',
+        c1ExpMs.description = Localization.getUpgradeIncCustomExpDesc('q_1',
         c1ExpInc);
-        c1ExpMs.info = Localization.getUpgradeIncCustomExpInfo('c_1', c1ExpInc);
+        c1ExpMs.info = Localization.getUpgradeIncCustomExpInfo('q_1', c1ExpInc);
         c1ExpMs.boughtOrRefunded = (_) => theory.invalidateSecondaryEquation();
     }
 
@@ -722,8 +722,8 @@ var getPrimaryEquation = () =>
 
 var getSecondaryEquation = () =>
 {
-    let result = `\\begin{matrix}\\dot{\\rho}=c_1${c1ExpMs.level > 0 ?
-    `^{${getc1Exponent(c1ExpMs.level)}}` : ''}c_2|c|,&${theory.latexSymbol}
+    let result = `\\begin{matrix}\\dot{\\rho}=|c|\\,q_1${c1ExpMs.level > 0 ?
+    `^{${getc1Exponent(c1ExpMs.level)}}` : ''}q_2,&${theory.latexSymbol}
     =\\max{\\rho}^{0.1}\\end{matrix}`;
     return result;
 }

--- a/collatz.js
+++ b/collatz.js
@@ -124,8 +124,8 @@ const locStrings =
         pausecDesc: ['Freeze {0}', 'Unfreeze {0}'],
         pausecInfo:
         [
-            'Freezes the iteration timer in place',
-            'Resumes the iteration timer'
+            'Freezes the turn timer in place',
+            'Resumes the turn timer'
         ],
 
         permaPause: '\\text{{the ability to freeze }}c',

--- a/collatz.js
+++ b/collatz.js
@@ -627,6 +627,9 @@ var tick = (elapsedTime, multiplier) =>
     if(elapsedTime > 0.1)
         log(`Long tick: ${elapsedTime.toFixed(3)}s`);
 
+    nudgec.isAutoBuyable = false;
+    incrementc.isAutoBuyable = false;
+
     if(pausec.level % 2 == 0)
     {
         ++time;

--- a/collatz.js
+++ b/collatz.js
@@ -79,7 +79,11 @@ const locStrings =
         alternating: ' (alternating)',
 
         achNegativeTitle: 'Shadow Realm',
-        achNegativeDesc: `Gone negative by publishing while c's level is odd.`,
+        achNegativeDesc: `Publish with an odd c level and go negative.`,
+        achMarathonTitle: 'Lothar-athon',
+        achMarathonDesc: 'Reach a c value of 1e60.',
+        achSixNineTitle: 'I\'m proud of you.',
+        achSixNineDesc: 'Reach a c value of 69.',
 
         btnClose: 'Close',
         btnNotationMode: ['Notation: Digits', 'Notation: Scientific'],
@@ -485,6 +489,11 @@ var init = () =>
 
     theory.createAchievement(0, undefined, getLoc('achNegativeTitle'),
     getLoc('achNegativeDesc'), () => cBigNum < 0);
+    theory.createAchievement(1, undefined, getLoc('achMarathonTitle'),
+    getLoc('achMarathonDesc'), () => cBigNum >= 1e60, () => c == 0n ? 0 :
+    cBigNum.log10().toNumber() / 60);
+    theory.createAchievement(2, undefined, getLoc('achSixNineTitle'),
+    getLoc('achSixNineDesc'), () => c == 69n);
 
     updateAvailability();
 

--- a/collatz.js
+++ b/collatz.js
@@ -32,6 +32,8 @@ var getDescription = (language) =>
 `A puzzle revolving around nudging a number's value in order to counteract ` +
 `the even clause of the Collatz conjecture.
 
+Note: for spoiler purposes, sharing sequences to new players is ill-advised.
+
 'If it's odd, triple it plus one,
 If it's even, divide it in two.
 

--- a/collatz.js
+++ b/collatz.js
@@ -122,9 +122,9 @@ const locStrings =
         pausecInfo: '\\text{Freezes }c\\text{\'s value}',
 
         permaPause: '\\text{{the ability to freeze }}c',
-        permaIncrement: '\\text{{extra increments of }}c',
-        permaIncrementInfo: `\\text{{Does not alternate; incurs penalty on }}c
-        \\text{{\'s level}}`,
+        permaIncrement: `\\text{{extra in/decrements of }}c`,
+        permaIncrementInfo: `\\text{{Dependent on }}c
+        \\text{{'s sign, and incurs penalty on its level}}`,
         permaPreserveDesc: '\\text{Preserve }c\\text{ after publishing}',
         permaPreserveInfo: '\\text{Preserves }c\\text{ after publishing}',
 
@@ -139,7 +139,7 @@ const locStrings =
         condition: `\\text{{if }}{{{0}}}`,
 
         alternating: ' (alternating)',
-        notAlternating: 'c \\text{ level penalty} = ',
+        penalty: 'c \\text{ level penalty} = ',
         deductFromc: '\\text{{ (- }} {{{0}}} \\text{{ levels from }}c)',
 
         ch1Title: 'Preface',
@@ -155,7 +155,7 @@ It's thesis time.`,
 
         achNegativeTitle: 'Shrouded by Fog',
         achNegativeDesc: `Publish with an odd level of c and go negative.`,
-        achMarathonTitle: 'The Annual Lothar-athon',
+        achMarathonTitle: 'Annual Lothar-athon',
         achMarathonDesc: 'Reach a c value of ±1e60.',
         achSixNineTitle: 'I\'m proud of you.',
         achSixNineDesc: 'Reach a c value of 69.',
@@ -476,20 +476,23 @@ var init = () =>
     and negative.
     */
     {
-        let getDesc = (level) => `c \\leftarrow c+1${Localization.format(
-        getLoc('deductFromc'), getIncrementPenalty(level))}`;
+        let getDesc = (level) => `c \\leftarrow c${c < 0n ? '-' : '+'}1
+        ${Localization.format(getLoc('deductFromc'),
+        getIncrementPenalty(level))}`;
         incrementc = theory.createUpgrade(3, currency, new FreeCost);
         incrementc.getDescription = () => Utils.getMath(getDesc(
         incrementc.level));
-        incrementc.getInfo = (amount) =>
-        `${Utils.getMath(getLoc('notAlternating'))}
+        incrementc.getInfo = (amount) => `${Utils.getMath(getLoc('penalty'))}
         ${Utils.getMathTo(getIncrementPenalty(incrementc.level),
         getIncrementPenalty(incrementc.level + amount))}`;
         incrementc.bought = (_) =>
         {
             // if(writeHistory)
             //     history[nudgec.level + incrementc.level] = c.toString();
-            c += 1n;
+            if(c < 0n)
+                c -= 1n;
+            else
+                c += 1n;
 
             cBigNum = BigNumber.from(c);
             theory.invalidatePrimaryEquation();

--- a/collatz.js
+++ b/collatz.js
@@ -140,7 +140,7 @@ const locStrings =
         achNegativeTitle: 'Shadow Realm',
         achNegativeDesc: `Publish with an odd level of c and go negative.`,
         achMarathonTitle: 'Lothar-athon',
-        achMarathonDesc: 'Reach a c value of 1e60.',
+        achMarathonDesc: 'Reach a c value of ±1e60.',
         achSixNineTitle: 'I\'m proud of you.',
         achSixNineDesc: 'Reach a c value of 69.',
 
@@ -565,8 +565,8 @@ var init = () =>
     theory.createAchievement(0, undefined, getLoc('achNegativeTitle'),
     getLoc('achNegativeDesc'), () => cBigNum < 0);
     theory.createAchievement(1, undefined, getLoc('achMarathonTitle'),
-    getLoc('achMarathonDesc'), () => cBigNum >= 1e60, () => c == 0n ? 0 :
-    cBigNum.log10().toNumber() / 60);
+    getLoc('achMarathonDesc'), () => cBigNum.abs() >= 1e60, () => c == 0n ? 0 :
+    cBigNum.abs().log10().toNumber() / 60);
     theory.createAchievement(2, undefined, getLoc('achSixNineTitle'),
     getLoc('achSixNineDesc'), () => c == 69n);
 

--- a/collatz.js
+++ b/collatz.js
@@ -56,7 +56,7 @@ const locStrings =
     {
         versionName: 'v0.06',
         workInProgress: ', Work in\\\\Progress',
-        
+
         historyDesc: `\\begin{{array}}{{c}}\\text{{History}}\\\\{{{0}}}/{{{1}}}
 \\end{{array}}`,
         historyInfo: 'Shows the last and current runs\' sequences',
@@ -131,7 +131,7 @@ let getSciBinString = (n) =>
     let s = BigInt(n).toString(2);
     if(s[0] == '-')
         offset = 2;
-    
+
     if(s.length < 9)
         return s;
 
@@ -248,7 +248,7 @@ var getCurrencyFromTau = (tau) =>
 
 const permaCosts = bigNumArray(['1e12', '1e22', '1e31', '1e66']);
 const milestoneCost = new CompositeCost(2, new LinearCost(4.4, 4.4),
-new CompositeCost(2, new LinearCost(17.6, 8.8), new LinearCost(35.2, 17.6)));
+new CompositeCost(2, new LinearCost(13.2, 8.8), new LinearCost(30.8, 13.2)));
 
 const cLevelCap = [24, 36, 52, 72];
 const cooldown = [42, 30, 20, 12];
@@ -377,7 +377,7 @@ var init = () =>
             if(c1ExpMs.level > 0)
                 return `c_1^{${getc1Exponent(c1ExpMs.level)}}=
                 ${getc1(level).pow(getc1Exponent(c1ExpMs.level)).toString()}`;
-            
+
             return getDesc(level);
         }
         c1 = theory.createUpgrade(1, currency, c1Cost);

--- a/collatz.js
+++ b/collatz.js
@@ -121,15 +121,19 @@ const locStrings =
         historyDesc: `\\begin{{array}}{{c}}\\text{{History}}\\\\{{{0}}}/{{{1}}}
         \\end{{array}}`,
         historyInfo: 'Shows the last and current runs\' sequences',
-        pausecDesc: ['\\text{Freeze }c', '\\text{Unfreeze }c'],
-        pausecInfo: '\\text{Freezes }c\\text{ value}',
+        pausecDesc: ['Freeze {0}', 'Unfreeze {0}'],
+        pausecInfo:
+        [
+            'Freezes the iteration timer in place',
+            'Resumes the iteration timer'
+        ],
 
         permaPause: '\\text{{the ability to freeze }}c',
         permaIncrement: `\\text{{extra in/decrements for }}c`,
-        permaIncrementInfo: `\\text{{Dependent on }}c
-        \\text{{'s sign, and incurs penalty on its level}}`,
-        permaPreserveDesc: '\\text{Preserve }c\\text{ after publishing}',
-        permaPreserveInfo: '\\text{Preserves }c\\text{ after publishing}',
+        permaIncrementInfo: `Dependent on {0}'s sign, and incurs a penalty ` +
+`on its level`,
+        // permaPreserveDesc: '\\text{Preserve }c\\text{ after publishing}',
+        // permaPreserveInfo: '\\text{Preserves }c\\text{ after publishing}',
 
         q1Level: 'q_1\\text{{ level}}',
         cLevel: '1/{{{0}}}\\text{{{{ of }}}}c\\text{{{{ level}}}}',
@@ -142,7 +146,7 @@ const locStrings =
         condition: `\\text{{if }}{{{0}}}`,
 
         alternating: ' (alternating)',
-        penalty: 'c \\text{ level penalty} = ',
+        penalty: '{0} level penalty = ',
         deductFromc: '\\text{{ (- }} {{{0}}} \\text{{ levels from }}c)',
 
         ch1Title: 'Preface',
@@ -159,7 +163,7 @@ It's thesis time.`,
         achNegativeTitle: 'Shrouded by Fog',
         achNegativeDesc: `Publish with an odd level of c and go negative.`,
         achMarathonTitle: 'Annual Lothar-athon',
-        achMarathonDesc: 'Reach a c value of ±1e60.\n\nReward: +1 to q2.',
+        achMarathonDesc: 'Reach a c value of ±1e60. Reward: +1 to q2.',
         achSixNineTitle: 'I\'m proud of you.',
         achSixNineDesc: 'Reach a c value of 69.',
 
@@ -415,9 +419,9 @@ var init = () =>
     */
     {
         pausec = theory.createSingularUpgrade(3, currency, new FreeCost);
-        pausec.getDescription = () => Utils.getMath(getLoc(
-        'pausecDesc')[pausec.level & 1]);
-        pausec.info = Utils.getMath(getLoc('pausecInfo'));
+        pausec.getDescription = () => Localization.format(getLoc(
+        'pausecDesc')[pausec.level & 1], Utils.getMath('c'));
+        pausec.getInfo = () => getLoc('pausecInfo')[pausec.level & 1];
     }
     /* Nudge c
     The theory's core mechanic revolves around nudging c around. This upgrade
@@ -502,7 +506,8 @@ var init = () =>
         incrementc = theory.createUpgrade(3, currency, new FreeCost);
         incrementc.getDescription = () => Utils.getMath(getDesc(
         incrementc.level));
-        incrementc.getInfo = (amount) => `${Utils.getMath(getLoc('penalty'))}
+        incrementc.getInfo = (amount) => `${Localization.format(
+        getLoc('penalty'), Utils.getMath('c'))}
         ${Utils.getMathTo(getIncrementPenalty(incrementc.level),
         getIncrementPenalty(incrementc.level + amount))}`;
         incrementc.bought = (_) =>
@@ -550,7 +555,8 @@ var init = () =>
         new ConstantCost(permaCosts[4]));
         extraIncPerma.description = Localization.getUpgradeUnlockDesc(getLoc(
         'permaIncrement'));
-        extraIncPerma.info = Utils.getMath(getLoc('permaIncrementInfo'));
+        extraIncPerma.info = Localization.format(getLoc('permaIncrementInfo'),
+        Utils.getMath('c'));
         extraIncPerma.bought = (_) => updateAvailability();
         extraIncPerma.maxLevel = 1;
     }

--- a/collatz.js
+++ b/collatz.js
@@ -937,8 +937,8 @@ var setInternalState = (stateStr) =>
     if('time' in state)
     {
         time = state.time;
-        cIterProgBar.progressTo((time / (cooldown[cooldownMs.level] - 1)) **
-        1.5, 220, Easing.CUBIC_INOUT);
+        cIterProgBar.progress = (time / (cooldown[cooldownMs.level] - 1)) **
+        1.5;
     }
     if('c' in state)
     {

--- a/collatz.js
+++ b/collatz.js
@@ -64,7 +64,7 @@ let bigNumArray = (array) => array.map(x => BigNumber.from(x));
 
 const borrowFactor = 4;
 const c1Cost = new FirstFreeCost(new ExponentialCost(1, 3.01));
-const getIncrementPenalty = (level) => 2 * Utils.getStepwisePowerSum(level,
+const getIncrementPenalty = (level) => Utils.getStepwisePowerSum(level,
 2, 4, 0).toNumber();
 const getc1BonusLevels = (bl, pl) => Math.max(Math.floor((bl * nudgec.level - 
 getIncrementPenalty(pl)) / borrowFactor), 0);

--- a/collatz.js
+++ b/collatz.js
@@ -210,6 +210,33 @@ const cIterProgBar = ui.createProgressBar
 ({
     margin: new Thickness(6, 0)
 });
+/* Image size reference
+Size 20:
+270x480
+
+Size 24:
+360x640
+450x800
+540x960
+
+Size 36:
+720x1280
+
+Size 48:
+1080x1920
+*/
+let getImageSize = (width) =>
+{
+    if(width >= 1080)
+        return 48;
+    if(width >= 720)
+        return 36;
+    if(width >= 360)
+        return 24;
+    
+    return 20;
+}
+
 const historyFrame = ui.createFrame
 ({
     isVisible: false,
@@ -218,9 +245,9 @@ const historyFrame = ui.createFrame
     cornerRadius: 1,
     horizontalOptions: LayoutOptions.END,
     verticalOptions: LayoutOptions.START,
-    margin: new Thickness(10),
+    margin: new Thickness(9.5),
     hasShadow: true,
-    heightRequest: 24,
+    heightRequest: getImageSize(ui.screenWidth),
     content: ui.createImage
     ({
         // margin: new Thickness(2),
@@ -246,7 +273,7 @@ const historyLabel = ui.createLatexLabel
     column: 2,
     horizontalOptions: LayoutOptions.END,
     verticalOptions: LayoutOptions.START,
-    margin: new Thickness(3, 40),
+    margin: new Thickness(2.5, 40),
     text: () => Utils.getMath(Localization.format(getLoc('historyDesc'),
     (nudgec ? nudgec.level : 0) + (incrementc ? incrementc.level : 0) -
     totalIncLevel, lastHistoryLength)),
@@ -468,6 +495,7 @@ var init = () =>
     there would align with c2 near perfectly at ~6 c1 upgrades per c2 upgrade.
     Collatz uses a (2, 5), which aligns more with tradition, while being twice
     more powerful.
+    Optimal cost ratios (mod 5): 2/6, 2/7, 2/8, 2/9, 2/10
     */
     {
         let getDesc = (level) => `q_1=${getq1(level).toString(0)}`;

--- a/collatz.js
+++ b/collatz.js
@@ -65,20 +65,20 @@ let bigNumArray = (array) => array.map(x => BigNumber.from(x));
 // All balance parameters are aggregated for ease of access
 
 const borrowFactor = 4;
-const c1Cost = new FirstFreeCost(new ExponentialCost(1, 3.01));
+const q1Cost = new FirstFreeCost(new ExponentialCost(1, 3.01));
 const getIncrementPenalty = (level) => Utils.getStepwisePowerSum(level,
 2, 4, 0).toNumber();
-const getc1BonusLevels = (bl, pl) => Math.max(Math.floor((bl * nudgec.level - 
+const getq1BonusLevels = (bl, pl) => Math.max(Math.floor((bl * nudgec.level - 
 getIncrementPenalty(pl)) / borrowFactor), 0);
-const getc1 = (level) => Utils.getStepwisePowerSum(level + getc1BonusLevels(
-c1BorrowMs.level, incrementc.level), 2, 5, 1);
+const getq1 = (level) => Utils.getStepwisePowerSum(level + getq1BonusLevels(
+q1BorrowMs.level, incrementc.level), 2, 5, 1);
 
-const c1ExpInc = 0.03;
-const c1ExpMaxLevel = 4;
-const getc1Exponent = (level) => 1 + c1ExpInc * level;
+const q1ExpInc = 0.03;
+const q1ExpMaxLevel = 4;
+const getq1Exponent = (level) => 1 + q1ExpInc * level;
 
-const c2Cost = new ExponentialCost(2.2e7, 11);
-const getc2 = (level) => BigNumber.THREE.pow(level);
+const q2Cost = new ExponentialCost(2.2e7, 11);
+const getq2 = (level) => BigNumber.THREE.pow(level);
 
 const permaCosts = bigNumArray(['1e12', '1e22', '1e31', '1e54', '1e160']);
 const milestoneCost = new CompositeCost(2, new LinearCost(4.4, 4.4),
@@ -93,9 +93,9 @@ var getPublicationMultiplier = (tau) => tau.pow(pubExp);
 var getPublicationMultiplierFormula = (symbol) => `{${symbol}}^{${pubExp}}`;
 
 var pausec;
-var nudgec, c1, c2, incrementc;
+var nudgec, q1, q2, incrementc;
 var pausePerma, extraIncPerma;
-var cooldownMs, c1BorrowMs, c1ExpMs;
+var cooldownMs, q1BorrowMs, q1ExpMs;
 
 var currency;
 
@@ -130,7 +130,7 @@ const locStrings =
         permaPreserveDesc: '\\text{Preserve }c\\text{ after publishing}',
         permaPreserveInfo: '\\text{Preserves }c\\text{ after publishing}',
 
-        c1Level: 'q_1\\text{{ level}}',
+        q1Level: 'q_1\\text{{ level}}',
         cLevel: '1/{{{0}}}\\text{{{{ of }}}}c\\text{{{{ level}}}}',
         cLevelth: `1/{{{0}}}^\\text{{{{th}}}}\\text{{{{ of }}}}c
         \\text{{{{ level}}}}`,
@@ -465,30 +465,30 @@ var init = () =>
     more powerful.
     */
     {
-        let getDesc = (level) => `q_1=${getc1(level).toString(0)}`;
+        let getDesc = (level) => `q_1=${getq1(level).toString(0)}`;
         let getInfo = (level) =>
         {
-            if(c1ExpMs.level > 0)
-                return `q_1^{${getc1Exponent(c1ExpMs.level)}}=
-                ${getc1(level).pow(getc1Exponent(c1ExpMs.level)).toString()}`;
+            if(q1ExpMs.level > 0)
+                return `q_1^{${getq1Exponent(q1ExpMs.level)}}=
+                ${getq1(level).pow(getq1Exponent(q1ExpMs.level)).toString()}`;
 
             return getDesc(level);
         }
-        c1 = theory.createUpgrade(1, currency, c1Cost);
-        c1.getDescription = (_) => Utils.getMath(getDesc(c1.level));
-        c1.getInfo = (amount) => Utils.getMathTo(getInfo(c1.level),
-        getInfo(c1.level + amount));
+        q1 = theory.createUpgrade(1, currency, q1Cost);
+        q1.getDescription = (_) => Utils.getMath(getDesc(q1.level));
+        q1.getInfo = (amount) => Utils.getMathTo(getInfo(q1.level),
+        getInfo(q1.level + amount));
     }
     /* q2 (c2 prior to 0.06)
     Standard doubling upgrade.
     */
     {
         let getDesc = (level) => `q_2=3^{${level}}`;
-        let getInfo = (level) => `q_2=${getc2(level).toString(0)}`;
-        c2 = theory.createUpgrade(2, currency, c2Cost);
-        c2.getDescription = (_) => Utils.getMath(getDesc(c2.level));
-        c2.getInfo = (amount) => Utils.getMathTo(getInfo(c2.level),
-        getInfo(c2.level + amount));
+        let getInfo = (level) => `q_2=${getq2(level).toString(0)}`;
+        q2 = theory.createUpgrade(2, currency, q2Cost);
+        q2.getDescription = (_) => Utils.getMath(getDesc(q2.level));
+        q2.getInfo = (amount) => Utils.getMathTo(getInfo(q2.level),
+        getInfo(q2.level + amount));
     }
     /* Increment c
     Unlike nudge, this upgrade only increments c. It is both weaker in positive
@@ -601,21 +601,21 @@ var init = () =>
     be farmed simply by doing a bunch of empty publishes at 1.00 multiplier.
     */
     {
-        c1BorrowMs = theory.createMilestoneUpgrade(1, 1);
-        c1BorrowMs.description = Localization.getUpgradeIncCustomDesc(getLoc(
-        'c1Level'), Localization.format(getLoc('cLevelth'), borrowFactor));
-        c1BorrowMs.info = Localization.getUpgradeIncCustomInfo(getLoc(
-        'c1Level'), Localization.format(getLoc('cLevelth'), borrowFactor));
+        q1BorrowMs = theory.createMilestoneUpgrade(1, 1);
+        q1BorrowMs.description = Localization.getUpgradeIncCustomDesc(getLoc(
+        'q1Level'), Localization.format(getLoc('cLevelth'), borrowFactor));
+        q1BorrowMs.info = Localization.getUpgradeIncCustomInfo(getLoc(
+        'q1Level'), Localization.format(getLoc('cLevelth'), borrowFactor));
     }
-    /* c1 exponent
+    /* q1 exponent
     Standard exponent upgrade.
     */
     {
-        c1ExpMs = theory.createMilestoneUpgrade(2, c1ExpMaxLevel);
-        c1ExpMs.description = Localization.getUpgradeIncCustomExpDesc('q_1',
-        c1ExpInc);
-        c1ExpMs.info = Localization.getUpgradeIncCustomExpInfo('q_1', c1ExpInc);
-        c1ExpMs.boughtOrRefunded = (_) => theory.invalidateSecondaryEquation();
+        q1ExpMs = theory.createMilestoneUpgrade(2, q1ExpMaxLevel);
+        q1ExpMs.description = Localization.getUpgradeIncCustomExpDesc('q_1',
+        q1ExpInc);
+        q1ExpMs.info = Localization.getUpgradeIncCustomExpInfo('q_1', q1ExpInc);
+        q1ExpMs.boughtOrRefunded = (_) => theory.invalidateSecondaryEquation();
     }
 
     theory.createStoryChapter(0, getLoc('ch1Title'), getLoc('ch1Desc'),
@@ -680,11 +680,11 @@ var tick = (elapsedTime, multiplier) =>
     }
 
     let dt = BigNumber.from(elapsedTime * multiplier);
-    let vc1 = getc1(c1.level).pow(getc1Exponent(c1ExpMs.level));
-    let vc2 = getc2(c2.level);
+    let q1Term = getq1(q1.level).pow(getq1Exponent(q1ExpMs.level));
+    let q2Term = getq2(q2.level);
     let bonus = theory.publicationMultiplier;
 
-    currency.value += dt * cBigNum.abs() * vc1 * vc2 * bonus;
+    currency.value += dt * cBigNum.abs() * q1Term * q2Term * bonus;
 }
 
 var getEquationOverlay = () =>
@@ -740,8 +740,8 @@ var getPrimaryEquation = () =>
 
 var getSecondaryEquation = () =>
 {
-    let result = `\\begin{matrix}\\dot{\\rho}=|c|\\,q_1${c1ExpMs.level > 0 ?
-    `^{${getc1Exponent(c1ExpMs.level)}}` : ''}q_2,&${theory.latexSymbol}
+    let result = `\\begin{matrix}\\dot{\\rho}=|c|\\,q_1${q1ExpMs.level > 0 ?
+    `^{${getq1Exponent(q1ExpMs.level)}}` : ''}q_2,&${theory.latexSymbol}
     =\\max{\\rho}^{0.1}\\end{matrix}`;
     return result;
 }

--- a/collatz.js
+++ b/collatz.js
@@ -232,7 +232,7 @@ let getSciBinString = (n) =>
     if(s[0] == '-')
         offset = 2;
 
-    if(s.length < 9)
+    if(s.length < 8)
         return s;
 
     let exponent = s.length - offset;

--- a/collatz.js
+++ b/collatz.js
@@ -98,12 +98,12 @@ const locStrings =
         versionName: 'v0.06',
         workInProgress: ', WIP',//', Work in\\\\Progress',
         changeLog: `\\text{Change log!}\\\\ \\begin{array}{l}
-\\bullet \\text{ Pub:}\\\\ \\frac{{\\tau}^{5.22}}{31} \\rightarrow
+\\bullet \\text{ Pub formula~}\\\\ \\frac{{\\tau}^{5.22}}{31} \\rightarrow
 {\\tau}^{4.72}\\\\
-\\bullet \\text{ } c_1 \\text{ level ms:}\\\\
+\\bullet \\text{ } c_1 \\text{ level ms~}\\\\
 1/2 \\rightarrow 1/4,\\\\
 \\text{rounded down}\\\\
-\\bullet \\text{ Freeze cost:}\\\\ 1e66 \\rightarrow 1e54\\\\
+\\bullet \\text{ Freeze cost~}\\\\ 1e66 \\rightarrow 1e54\\\\
 \\bullet \\text{ Spaced out}\\\\ \\text{ms costs}\\\\
 \\end{array}`,
 

--- a/collatz.js
+++ b/collatz.js
@@ -74,10 +74,10 @@ const c1ExpInc = 0.03;
 const c1ExpMaxLevel = 4;
 const getc1Exponent = (level) => 1 + c1ExpInc * level;
 
-const c2Cost = new ExponentialCost(1e6, 11);
-const getc2 = (level) => BigNumber.TWO.pow(level);
+const c2Cost = new ExponentialCost(2.2e7, 11);
+const getc2 = (level) => BigNumber.THREE.pow(level);
 
-const permaCosts = bigNumArray(['1e12', '1e22', '1e31', '1e54']);
+const permaCosts = bigNumArray(['1e12', '1e22', '1e31', '1e54', '1e160']);
 const milestoneCost = new CompositeCost(2, new LinearCost(4.4, 4.4),
 new CompositeCost(2, new LinearCost(13.2, 8.8), new LinearCost(30.8, 13.2)));
 
@@ -85,7 +85,7 @@ const cLevelCap = [24, 36, 52, 72];
 const cooldown = [42, 30, 20, 12];
 
 const tauRate = 0.1;
-const pubExp = 4.72;
+const pubExp = 4.2;
 var getPublicationMultiplier = (tau) => tau.pow(pubExp);
 var getPublicationMultiplierFormula = (symbol) => `{${symbol}}^{${pubExp}}`;
 
@@ -101,7 +101,7 @@ const locStrings =
     en:
     {
         versionName: 'v0.06',
-        workInProgress: ', WIP',//', Work in\\\\Progress',
+        workInProgress: /*', WIP',*/', Work in\\\\Progress',
         changeLog: `\\text{Change log!}\\\\ \\begin{array}{l}
 \\bullet \\text{ Now grants}\\\\ \\text{increments at}\\\\
 \\text{72 nudge levels}\\\\
@@ -136,7 +136,18 @@ const locStrings =
 
         alternating: ' (alternating)',
         notAlternating: 'Does not alternate; penalty = ',
-        deductFromc: '\\text{{ (-}} {{{0}}} \\text{{ levels of }}c)',
+        deductFromc: '\\text{{ (- }} {{{0}}} \\text{{ levels from }}c)',
+
+        ch1Title: 'Preface',
+        ch1Desc: `You are a talented undergraduate student.
+Your professors see a bright future ahead of you.
+One you respect hands you a formula,
+then asks you if it converges into a finite cycle.
+It is a modular recursive equation.
+Not knowing how to solve it, you nudge the value
+behind their backs.
+
+It's thesis time.`,
 
         achNegativeTitle: 'Shadow Realm',
         achNegativeDesc: `Publish with an odd level of c and go negative.`,
@@ -449,7 +460,7 @@ var init = () =>
     Standard doubling upgrade.
     */
     {
-        let getDesc = (level) => `c_2=2^{${level}}`;
+        let getDesc = (level) => `c_2=3^{${level}}`;
         let getInfo = (level) => `c_2=${getc2(level).toString(0)}`;
         c2 = theory.createUpgrade(2, currency, c2Cost);
         c2.getDescription = (_) => Utils.getMath(getDesc(c2.level));
@@ -565,6 +576,9 @@ var init = () =>
         c1ExpMs.boughtOrRefunded = (_) => theory.invalidateSecondaryEquation();
     }
 
+    theory.createStoryChapter(0, getLoc('ch1Title'), getLoc('ch1Desc'),
+    () => true);
+
     theory.createAchievement(0, undefined, getLoc('achNegativeTitle'),
     getLoc('achNegativeDesc'), () => cBigNum < 0);
     theory.createAchievement(1, undefined, getLoc('achMarathonTitle'),
@@ -637,8 +651,8 @@ var getEquationOverlay = () =>
                 column: 0,
                 verticalOptions: LayoutOptions.START,
                 margin: new Thickness(6, 3),
-                text: getLoc('versionName') + getLoc('workInProgress') +
-                Utils.getMath(getLoc('changeLog')),
+                text: getLoc('versionName') + getLoc('workInProgress')/* +
+                Utils.getMath(getLoc('changeLog'))*/,
                 fontSize: 9,
                 textColor: Color.TEXT_MEDIUM
             }),

--- a/collatz.js
+++ b/collatz.js
@@ -69,13 +69,17 @@ const locStrings =
 
         c1Level: 'c_1\\text{{ level}}',
         cLevel: '1/{{{0}}}\\text{{{{ of }}}}c\\text{{{{\'s level}}}}',
-        cLevelth: '1/{{{0}}}^\\text{{{{th}}}}\\text{{{{ of }}}}c\\text{{{{\'s level}}}}',
+        cLevelth: `1/{{{0}}}^\\text{{{{th}}}}\\text{{{{ of }}}}c
+        \\text{{{{\'s level}}}}`,
         cLevelCap: 'c\\text{{ level cap}}',
         cooldown: '\\text{{interval}}',
         cooldownInfo: 'Interval',
         nTicks: '{{{0}}}\\text{{{{ ticks}}}}',
 
         alternating: ' (alternating)',
+
+        achNegativeTitle: 'Shadow Realm',
+        achNegativeDesc: `Gone negative by publishing while c's level is odd.`,
 
         btnClose: 'Close',
         btnNotationMode: ['Notation: Digits', 'Notation: Scientific'],
@@ -478,6 +482,9 @@ var init = () =>
         c1ExpMs.info = Localization.getUpgradeIncCustomExpInfo('c_1', c1ExpInc);
         c1ExpMs.boughtOrRefunded = (_) => theory.invalidateSecondaryEquation();
     }
+
+    theory.createAchievement(0, undefined, getLoc('achNegativeTitle'),
+    getLoc('achNegativeDesc'), () => cBigNum < 0);
 
     updateAvailability();
 

--- a/collatz.js
+++ b/collatz.js
@@ -144,10 +144,25 @@ let getSciBinString = (n) =>
         return s;
 
     let exponent = s.length - offset;
+    // Negative
     if(s[0] == '-')
     {
         if(exponent >= 1000000)
-            return getLoc('errorBinExpLimit');
+        {
+            let expofExp = Math.log10(exponent);
+            if(expofExp >= 100000)  // -eee5.00     I'm lazy.
+                return getLoc('errorBinExpLimit');
+            if(expofExp >= 10000)   // -ee10000
+                return `${s[0]}ee${expofExp.toFixed(0)}`;
+            if(expofExp >= 1000)    // -ee1000.
+                return `${s[0]}ee${expofExp.toFixed(0)}.`;
+            if(expofExp >= 100)     // -ee100.0
+                return `${s[0]}ee${expofExp.toFixed(1)}`;
+            if(expofExp >= 10)      // -ee10.00
+                return `${s[0]}ee${expofExp.toFixed(2)}`;
+                                    // -ee6.000
+            return `${s[0]}ee${expofExp.toFixed(3)}`;
+        }
         if(exponent >= 100000)  // -e100000
             return `${s[0]}e${exponent}`;
         if(exponent >= 10000)   // -1e10000
@@ -161,10 +176,25 @@ let getSciBinString = (n) =>
                                 // -1.000e9
         return `${s.slice(0, 2)}.${s.slice(2, 5)}e${exponent}`;
     }
-    if(exponent >= 10000000)
-        return getLoc('errorBinExpLimit');
-    if(exponent >= 1000000) // e1000000
-        return `e${exponent}`;
+    // Positive
+    if(exponent >= 1000000)
+    {
+        let expofExp = Math.log10(exponent);
+        if(expofExp >= 1000000) // eee6.000     I'm lazy.
+            return getLoc('errorBinExpLimit');
+        if(expofExp >= 100000)  // ee100000
+            return `ee${expofExp.toFixed(0)}`;
+        if(expofExp >= 10000)   // ee10000.
+            return `ee${expofExp.toFixed(0)}.`;
+        if(expofExp >= 1000)    // ee1000.0
+            return `ee${expofExp.toFixed(1)}`;
+        if(expofExp >= 100)     // ee100.00
+            return `ee${expofExp.toFixed(2)}`;
+        if(expofExp >= 10)      // ee10.000
+            return `ee${expofExp.toFixed(3)}`;
+                                // ee6.0000
+        return `ee${expofExp.toFixed(4)}`;
+    }
     if(exponent >= 100000)  // 1e100000
         return `${s[0]}e${exponent}`;
     if(exponent >= 10000)   // 1.e10000

--- a/collatz.js
+++ b/collatz.js
@@ -32,7 +32,8 @@ var getDescription = (language) =>
 `A puzzle revolving around nudging a number's value in order to counteract ` +
 `the even clause of the Collatz conjecture.
 
-Note: for spoiler purposes, sharing sequences to new players is ill-advised.
+Warning: for spoiler purposes, it is ill-advised to
+share your sequences to new players.
 
 'If it's odd, triple it plus one,
 If it's even, divide it in two.
@@ -64,7 +65,7 @@ let bigNumArray = (array) => array.map(x => BigNumber.from(x));
 const borrowFactor = 4;
 const c1Cost = new FirstFreeCost(new ExponentialCost(1, 3.01));
 const getIncrementPenalty = (level) => 2 * Utils.getStepwisePowerSum(level,
-2, 4, 0);
+2, 4, 0).toNumber();
 const getc1BonusLevels = (bl, pl) => Math.max(Math.floor((bl * nudgec.level - 
 getIncrementPenalty(pl)) / borrowFactor), 0);
 const getc1 = (level) => Utils.getStepwisePowerSum(level + getc1BonusLevels(
@@ -149,9 +150,9 @@ behind their backs.
 
 It's thesis time.`,
 
-        achNegativeTitle: 'Shadow Realm',
+        achNegativeTitle: 'Shrouded by Fog',
         achNegativeDesc: `Publish with an odd level of c and go negative.`,
-        achMarathonTitle: 'Lothar-athon',
+        achMarathonTitle: 'The Annual Lothar-athon',
         achMarathonDesc: 'Reach a c value of ±1e60.',
         achSixNineTitle: 'I\'m proud of you.',
         achSixNineDesc: 'Reach a c value of 69.',
@@ -473,13 +474,13 @@ var init = () =>
     */
     {
         let getDesc = (level) => `c \\leftarrow c+1${Localization.format(
-        getLoc('deductFromc'), getIncrementPenalty(level).toString(0))}`;
+        getLoc('deductFromc'), getIncrementPenalty(level))}`;
         incrementc = theory.createUpgrade(3, currency, new FreeCost);
         incrementc.getDescription = () => Utils.getMath(getDesc(
         incrementc.level));
         incrementc.getInfo = (amount) => `${getLoc('notAlternating')}
-        ${Utils.getMathTo(getIncrementPenalty(incrementc.level).toString(0),
-        getIncrementPenalty(incrementc.level + amount).toString(0))}`;
+        ${Utils.getMathTo(getIncrementPenalty(incrementc.level),
+        getIncrementPenalty(incrementc.level + amount))}`;
         incrementc.bought = (_) =>
         {
             // if(writeHistory)
@@ -863,8 +864,8 @@ var prePublish = () =>
     totalIncLevel = nudgec.level - getIncrementPenalty(incrementc.level);
     lastHistory = history;
     lastHistoryLength = Object.keys(lastHistory).length;
+    
 }
-
 var postPublish = () =>
 {
     time = 0;

--- a/collatz.js
+++ b/collatz.js
@@ -421,6 +421,11 @@ var init = () =>
         Localization.getUpgradeIncCustomInfo('c', 1)}${getLoc('alternating')}`;
         nudgec.bought = (_) =>
         {
+            if(nudgec.isAutoBuyable)
+            {
+                nudgec.refund(1);
+                return;
+            }
             if(writeHistory)
                 history[nudgec.level] = c.toString();
             // even level: -1, odd level: +1, because this is post-processing
@@ -487,6 +492,11 @@ var init = () =>
         getIncrementPenalty(incrementc.level + amount))}`;
         incrementc.bought = (_) =>
         {
+            if(incrementc.isAutoBuyable)
+            {
+                incrementc.refund(1);
+                return;
+            }
             // if(writeHistory)
             //     history[nudgec.level + incrementc.level] = c.toString();
             if(c < 0n)

--- a/collatz.js
+++ b/collatz.js
@@ -224,14 +224,8 @@ let getSequence = (sequence, numMode = 0, lvlMode = 0) =>
     return Utils.getMath(result);
 }
 
-const getc1 = (level) =>
-{
-    if(c1BorrowMs.level > 0)
-        return Utils.getStepwisePowerSum(level + incrementc.level /
-        borrowFactor, 2, 5, 1);
-    
-    return Utils.getStepwisePowerSum(level, 2, 5, 1);
-}
+const getc1 = (level) => Utils.getStepwisePowerSum(level + Math.floor(
+c1BorrowMs.level * incrementc.level / borrowFactor), 2, 5, 1);
 const borrowFactor = 4;
 const c1Cost = new FirstFreeCost(new ExponentialCost(1, 3.01));
 const c1ExpInc = 0.07;

--- a/collatz.js
+++ b/collatz.js
@@ -96,7 +96,16 @@ const locStrings =
     en:
     {
         versionName: 'v0.06',
-        workInProgress: ', Work in\\\\Progress',
+        workInProgress: ', WIP',//', Work in\\\\Progress',
+        changeLog: `\\text{Change log!}\\\\ \\begin{array}{l}
+\\bullet \\text{ Pub:}\\\\ \\frac{{\\tau}^{5.22}}{31} \\rightarrow
+{\\tau}^{4.72}\\\\
+\\bullet \\text{ } c_1 \\text{ level ms:}\\\\
+1/2 \\rightarrow 1/4,\\\\
+\\text{rounded down}\\\\
+\\bullet \\text{ Freeze cost:}\\\\ 1e66 \\rightarrow 1e54\\\\
+\\bullet \\text{ Spaced out}\\\\ \\text{ms costs}\\\\
+\\end{array}`,
 
         historyDesc: `\\begin{{array}}{{c}}\\text{{History}}\\\\{{{0}}}/{{{1}}}
         \\end{{array}}`,
@@ -583,7 +592,8 @@ var getEquationOverlay = () =>
                 column: 0,
                 verticalOptions: LayoutOptions.START,
                 margin: new Thickness(6, 3),
-                text: getLoc('versionName') + getLoc('workInProgress'),
+                text: getLoc('versionName') + getLoc('workInProgress') +
+                Utils.getMath(getLoc('changeLog')),
                 fontSize: 9,
                 textColor: Color.TEXT_MEDIUM
             }),

--- a/collatz.js
+++ b/collatz.js
@@ -765,7 +765,7 @@ var getEquationOverlay = () =>
                 column: 0,
                 verticalOptions: LayoutOptions.START,
                 margin: new Thickness(6, 3),
-                text: getLoc('versionName') + getLoc('workInProgress')/* +
+                text: getLoc('versionName') /*+ getLoc('workInProgress')/* +
                 Utils.getMath(getLoc('changeLog'))*/,
                 fontSize: 9,
                 textColor: Color.TEXT_MEDIUM

--- a/collatz.js
+++ b/collatz.js
@@ -233,8 +233,32 @@ let getImageSize = (width) =>
         return 36;
     if(width >= 360)
         return 24;
-    
+
     return 20;
+}
+
+let getSmallBtnSize = (width) =>
+{
+    if(width >= 1080)
+        return 88;
+    if(width >= 720)
+        return 66;
+    if(width >= 360)
+        return 44;
+
+    return 36;
+}
+
+let getSeparatorSize = (width) =>
+{
+    if(width >= 1080)
+        return 25;
+    if(width >= 720)
+        return 19;
+    if(width >= 360)
+        return 13;
+
+    return 11;
 }
 
 const historyFrame = ui.createFrame
@@ -495,7 +519,11 @@ var init = () =>
     there would align with c2 near perfectly at ~6 c1 upgrades per c2 upgrade.
     Collatz uses a (2, 5), which aligns more with tradition, while being twice
     more powerful.
-    Optimal cost ratios (mod 5): 2/6, 2/7, 2/8, 2/9, 2/10
+    Optimal cost ratios (mod 5) against q2: 3/(10+2r) --> inverse: 4+0.667r
+    r=1,    2,     3,     4,     5
+    3/12,   14,    16,    18,    20
+    0.25, 0.214, 0.188, 0.167, 0.15
+      4,  4.667, 5,333,   6,   6,667
     */
     {
         let getDesc = (level) => `q_1=${getq1(level).toString(0)}`;
@@ -875,7 +903,12 @@ let createHistoryMenu = () =>
     });
     let historyGrid = ui.createGrid
     ({
-        rowDefinitions: ['24', '13', 'auto'],
+        rowDefinitions:
+        [
+            getImageSize(ui.screenWidth),
+            'auto',
+            'auto'
+        ],
         columnDefinitions: ['1*', '1*'],
         columnSpacing: 0,
         children:
@@ -900,12 +933,14 @@ let createHistoryMenu = () =>
             ({
                 row: 1,
                 column: 0,
+                heightRequest: 1,
                 margin: new Thickness(0, 6)
             }),
             ui.createBox
             ({
                 row: 1,
                 column: 1,
+                heightRequest: 1,
                 margin: new Thickness(0, 6)
             }),
             currentPubHistory,
@@ -923,7 +958,7 @@ let createHistoryMenu = () =>
             [
                 ui.createGrid
                 ({
-                    rowDefinitions: [44],
+                    rowDefinitions: [getSmallBtnSize(ui.screenWidth)],
                     columnDefinitions: ['8*', '5*', '9*'],
                     columnSpacing: 8,
                     children:

--- a/collatz.js
+++ b/collatz.js
@@ -47,7 +47,7 @@ what would you do?'`,
 var authors = 'propfeds#5988\n\nThanks to:\nCipher#9599, for the idea';
 var version = 0.06;
 
-let moves = 0;
+let turns = 0;
 let time = 0;
 let c = 0n;
 let cBigNum = BigNumber.from(c);
@@ -163,8 +163,8 @@ It's thesis time.`,
         achSixNineDesc: 'Reach a c value of 69.',
 
         btnClose: 'Close',
-        btnIndexingMode: ['Indexing: Moves', 'Indexing: Levels'],
-        btnNotationMode: ['Notation: Digits', 'Notation: Scientific'],
+        btnIndexingMode: ['Indexing: Turns (t)', 'Indexing: Levels'],
+        btnNotationMode: ['Disp.: Digits', 'Disp.: Scientific'],
         btnBaseMode: ['Base: 10', 'Base: 2'],
         errorInvalidNumMode: 'Invalid number mode',
         errorBinExpLimit: 'Too big',
@@ -441,7 +441,7 @@ var init = () =>
                 return;
             }
             if(writeHistory)
-                history[nudgec.level] = [moves, c.toString()];
+                history[nudgec.level] = [turns, c.toString()];
             // even level: -1, odd level: +1, because this is post-processing
             if(nudgec.level & 1)
                 c += 1n;
@@ -669,7 +669,7 @@ var tick = (elapsedTime, multiplier) =>
 
             cBigNum = BigNumber.from(c);
             if(nudgec.level > totalIncLevel)
-                ++moves;
+                ++turns;
             theory.invalidatePrimaryEquation();
             theory.invalidateTertiaryEquation();
             time -= cooldown[cooldownMs.level];
@@ -751,7 +751,7 @@ var getTertiaryEquation = () =>
     let mStr = '';
     let cStr = '';
     if(reachedFirstPub)
-        mStr = `t=${moves}`;
+        mStr = `t=${turns}`;
     if(historyNumMode & 2 || c > 1e6 || c < -1e6)
         cStr = `c=${cBigNum.toString(0)}`;
 
@@ -947,7 +947,7 @@ var prePublish = () =>
 }
 var postPublish = () =>
 {
-    moves = 0;
+    turns = 0;
     time = 0;
     // Disabling history write circumvents the extra levelling
     writeHistory = false;
@@ -986,7 +986,7 @@ var resetStage = () =>
 var getInternalState = () => JSON.stringify
 ({
     version: version,
-    moves: moves,
+    turns: turns,
     time: time,
     c: c.toString(),
     totalIncLevel: totalIncLevel,
@@ -1002,8 +1002,8 @@ var setInternalState = (stateStr) =>
         return;
 
     let state = JSON.parse(stateStr);
-    if('moves' in state)
-        moves = state.moves;
+    if('turns' in state)
+        turns = state.turns;
     if('time' in state)
     {
         time = state.time;

--- a/collatz.js
+++ b/collatz.js
@@ -122,7 +122,7 @@ const locStrings =
         pausecInfo: '\\text{Freezes }c\\text{\'s value}',
 
         permaPause: '\\text{{the ability to freeze }}c',
-        permaIncrement: `\\text{{extra in/decrements of }}c`,
+        permaIncrement: `\\text{{extra in/decrements for }}c`,
         permaIncrementInfo: `\\text{{Dependent on }}c
         \\text{{'s sign, and incurs penalty on its level}}`,
         permaPreserveDesc: '\\text{Preserve }c\\text{ after publishing}',

--- a/collatz.js
+++ b/collatz.js
@@ -284,7 +284,7 @@ var getCurrencyFromTau = (tau) =>
     currency.symbol
 ];
 
-const permaCosts = bigNumArray(['1e12', '1e22', '1e31', '1e66']);
+const permaCosts = bigNumArray(['1e12', '1e22', '1e31', '1e54']);
 const milestoneCost = new CompositeCost(2, new LinearCost(4.4, 4.4),
 new CompositeCost(2, new LinearCost(13.2, 8.8), new LinearCost(30.8, 13.2)));
 

--- a/conjoiner.js
+++ b/conjoiner.js
@@ -75,7 +75,7 @@ const locStrings =
 {
     en:
     {
-        versionName: 'v0.01',
+        versionName: 'v0.01b',
         workInProgress: /*', WIP',*/', Work in\\\\Progress',
         changeLog: `\\text{Change log!}\\\\ \\begin{array}{l}
 \\bullet \\text{ Now grants}\\\\ \\text{increments at}\\\\
@@ -403,7 +403,7 @@ var init = () =>
             cBigNum = BigNumber.from(c);
             choices = [c.toString()];
             choiceNav.level = 0;
-            if(nudgec.level >= 24)
+            if(nudgec.level == 24)
             {
                 currency.value += 1;
                 updateAvailability();

--- a/conjoiner.js
+++ b/conjoiner.js
@@ -386,7 +386,7 @@ var init = () =>
         Localization.getUpgradeIncCustomInfo('c', 1)}${getLoc('alternating')}`;
         nudgec.bought = (_) =>
         {
-            if(nudgec.isAutoBuyable || choices.length < 2)
+            if(nudgec.isAutoBuyable)
             {
                 nudgec.refund(1);
                 return;
@@ -402,7 +402,7 @@ var init = () =>
 
             cBigNum = BigNumber.from(c);
             choices = [c.toString()];
-            choiceNav.level = 1;
+            choiceNav.level = 0;
             if(nudgec.level >= 24)
             {
                 currency.value += 1;
@@ -412,8 +412,27 @@ var init = () =>
             theory.invalidateSecondaryEquation();
             theory.invalidateTertiaryEquation();
         }
+        nudgec.refunded = (_) =>
+        {
+            if(nudgec.isAutoBuyable)
+            {
+                nudgec.refund(1);
+                return;
+            }
+            turns = history[nudgec.level + 1][0];
+            c = BigInt(history[nudgec.level + 1][1]);
+            // if(nudgec.level & 1)
+            //     c = BigInt(target) + 1n;
+            // else
+            //     c = BigInt(target) - 1n;
+            cBigNum = BigNumber.from(c);
+            choices = [c.toString()];
+            choiceNav.level = 0;
+            theory.invalidatePrimaryEquation();
+            theory.invalidateSecondaryEquation();
+            theory.invalidateTertiaryEquation();
+        }
         nudgec.isAutoBuyable = false;
-        nudgec.canBeRefunded = () => false;
     }
     {
         choiceNav = theory.createUpgrade(1, currency, new FreeCost);
@@ -459,6 +478,7 @@ var init = () =>
         }
         incrementc.isAutoBuyable = false;
         incrementc.isAvailable = false;
+        incrementc.canBeRefunded = () => false;
     }
 
     theory.createPublicationUpgrade(0, currency, 0);
@@ -511,7 +531,6 @@ var tick = (elapsedTime, multiplier) =>
     for(let i = 0; i < 100; ++i)
     {
         let tmpc = BigInt(choices[choices.length - 1]);
-
         if((tmpc == 0n || tmpc == 1n || tmpc == -1n || tmpc == -5n ||
         tmpc == -17n) && choices.length > 20)
             break;

--- a/conjoiner.js
+++ b/conjoiner.js
@@ -393,6 +393,7 @@ var init = () =>
             }
             // even level: -1, odd level: +1, because this is post-processing
             let target = choices[choiceNav.level];
+            turns += choiceNav.level;
             history[nudgec.level] = [turns, target];
             if(nudgec.level & 1)
                 c = BigInt(target) + 1n;
@@ -400,7 +401,6 @@ var init = () =>
                 c = BigInt(target) - 1n;
 
             cBigNum = BigNumber.from(c);
-            turns += choiceNav.level;
             choices = [c.toString()];
             choiceNav.level = 1;
             if(nudgec.level >= 24)
@@ -511,9 +511,10 @@ var tick = (elapsedTime, multiplier) =>
     for(let i = 0; i < 100; ++i)
     {
         let tmpc = BigInt(choices[choices.length - 1]);
-        if(tmpc in [1n, -1n, -5n, -17n] && choices.length > 20)
-            break;
 
+        if((tmpc == 0n || tmpc == 1n || tmpc == -1n || tmpc == -5n ||
+        tmpc == -17n) && choices.length > 20)
+            break;
         if(tmpc % 2n != 0)
             choices.push((3n * tmpc + 1n).toString());
         else
@@ -536,7 +537,7 @@ var getEquationOverlay = () =>
                 column: 0,
                 verticalOptions: LayoutOptions.START,
                 margin: new Thickness(6, 3),
-                text: getLoc('versionName') + getLoc('workInProgress')/* +
+                text: getLoc('versionName')/* + getLoc('workInProgress')/* +
                 Utils.getMath(getLoc('changeLog'))*/,
                 fontSize: 9,
                 textColor: Color.TEXT_MEDIUM

--- a/conjoiner.js
+++ b/conjoiner.js
@@ -121,8 +121,8 @@ const locStrings =
         deductFromc: '\\text{{ (- }} {{{0}}} \\text{{ levels from }}c)',
         choiceNav: 'Navigate choices',
         choiceNavInfo: 'Buy to move forward, refund to move backwards',
-        choice: `\\begin{{array}}{{c}}\\text{{Choose next number: }}{{{0}}}
-        \\\\({{{1}}})\\end{{array}}`,
+        choice: `\\begin{{array}}{{rcl}}&\\text{{Choose next number:}}\\\\
+        &{{{0}}}\\\\_{{{1}}}&({{{2}}})&_{{{3}}}\\end{{array}}`,
 
         achMarathonTitle: 'Annual Lothar-athon',
         achMarathonDesc: 'Reach a c value of ±1e60. Reward: +1 to q2.',
@@ -506,6 +506,7 @@ var init = () =>
 
     theory.primaryEquationHeight = 66;
     theory.primaryEquationScale = 0.9;
+    theory.secondaryEquationHeight = 66;
 }
 
 var updateAvailability = () =>
@@ -588,9 +589,13 @@ var getSecondaryEquation = () =>
 {
     let nStr = historyNumMode & 2 ? getShortBinaryString(
     choices[choiceNav.level]) : getShortString(choices[choiceNav.level]);
-    let sStr = BigNumber.from(choices[choiceNav.level]).toString(0);
+    let snStr = BigNumber.from(choices[choiceNav.level]).toString(0);
+    let pStr = choiceNav.level > 0 ?
+    BigNumber.from(choices[choiceNav.level - 1]).toString(0) : '\\O';
+    let sStr = choiceNav.level < choices.length - 1 ?
+    BigNumber.from(choices[choiceNav.level + 1]).toString(0) : '\\O';
 
-    return Localization.format(getLoc('choice'), nStr, sStr);
+    return Localization.format(getLoc('choice'), nStr, pStr, snStr, sStr);
 };
 
 var getTertiaryEquation = () =>

--- a/conjoiner.js
+++ b/conjoiner.js
@@ -386,7 +386,7 @@ var init = () =>
         Localization.getUpgradeIncCustomInfo('c', 1)}${getLoc('alternating')}`;
         nudgec.bought = (_) =>
         {
-            if(nudgec.isAutoBuyable)
+            if(nudgec.isAutoBuyable || choices.length < 2)
             {
                 nudgec.refund(1);
                 return;


### PR DESCRIPTION
Last update before simulating with @tredec! This one changes a whole lot, but resetting is not needed. Be sure to end a publication (and don't record any new history!) before updating.

Balance changes:
(c1 c2 have been renamed q1 q2 for distinction between them and c.)
- q2 base: 2 → 3, but to compensate,
- Publication multiplier: tau^5.22/31 → tau^4.2
- q1 borrow factor from c: 1/2 → 1/4, rounded down
- Freeze cost: e66 → e54
- Spaced out milestone costs further: e44, e88, e132, e220, e308, e440, e572, e704
- Added a new permanent upgrade to buy extra increments for c at a cost

Quality of Life & fixes:
- Added a companion theory, Collatz Conjoiner! This tool allows you to construct your own sequences without fear of the turn timer.
- The game now shows the number of turns passed, and the history menu will record it as well.
- The book icon and other UI elements now scale with your screen size.
- History scrolling is now enabled in both directions, in case the screen size is too small.
- Added 3 new achievements.
- Altered wording in various places.