### PR TITLE
🅱

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,9 +12,9 @@
   - Because once you've found what you love, the theory becomes just q1q2
   - Although, extra increments solve the setback from having to recover from overstaying pub
 
-- [ ] Farm rate is stronger than before
+- [ ] Farm rate is weaker than before
   - (55/2) / (72/4) = 1.53
-  - [x] For now, change into log2(Ec) / 10 -> half of rate before
+  - [x] For now, change into log2(Ec) / 10 -> 50.7% of rate before
   - Need more testing
 
 - [x] q1 turn into (2, 10) stepwise with low cost increment for activeness?

--- a/TODO.md
+++ b/TODO.md
@@ -21,11 +21,13 @@
 - [x] Balance later intervals to 22/14?
   - Recovery too strong, making the buying process chaotic
 
-- [ ] Farm rate is weaker than before
-  - (55/2) / (72/4) = 1.53
-  - [x] For now, change into log2(Ec) / 10 -> 50.7% of rate before
-  - Need more testing
-  - Currently: 76% (0.12 Eclog with 2, 8 q1)
+- [ ] Current farm rate compared to before
+  - 65.2% at e55 (6 extra levels)
+    - `(55*2/72) * log2(10) * 0.12 * (5/4) * (6/7)`
+  - 65.5% at e69 (24 extra levels, taking extra time into account)
+    - `(69*2/72) * log2(10) * 0.12 * (5/4) * (6/7) * (72/90)`
+    - Extra levels are actually not weaker than regular?
+  - (0.12 Eclog with 2, 8 q1 and 14 interval)
 
 - [x] q1 turn into (2, 10) stepwise with low cost increment for activeness?
   - 2.09 or just 1.76? divisible by 11 this time

--- a/TODO.md
+++ b/TODO.md
@@ -12,11 +12,11 @@
   - Because once you've found what you love, the theory becomes just q1q2
   - Although, extra increments solve the setback from having to recover from overstaying pub
 
-- [ ] q1 turn into (2, 10) stepwise with low cost increment for activeness?
+- [x] q1 turn into (2, 10) stepwise with low cost increment for activeness?
   - 2.09 or just 1.76? divisible by 11 this time
-- [ ] q2 return to 2^x
-  - [ ] Also solves the problem of 1st pub being too big
-- [ ] Add q3 (unlocked with milestone)
+- [x] q2 return to 2^x
+  - [x] Also solves the problem of 1st pub being too big
+- [x] Add q3 (unlocked with milestone)
   - (!) Consider other changes first like q1 and log10(Ec/r)
   - q3 = 3^lv (+1 with badge)
   - Probably gonna make the milestone compete with q1 exponent
@@ -25,19 +25,21 @@
     - But not too small to make it reasonable
     - Is it too late to be that strong?
     - Or unlock it at e120 or sth and nerf pub exp to like 2.2 lol
-- [ ] Extra levels instead impose penalty by dividing the whole income
+- [x] Extra levels instead impose penalty by dividing the whole income
   - rho dot = q1q2|Ec|/(2^r), with r being a (2, 4) stepwise (wtf??)
+    - Or maybe (2, 6) and buff final cap to 66 (18/30/48/66)
     - Story: You begin attaching random /2s in your sequence in hopes of not being discovered...
   - I'll figure out the best form of punishment later when playtesting
   - This sounds like a legit good level farming method
   - Needs a max level, not too high to be abuseable, not too low to be worthless
-- [ ] q1 milestone buffs level by log10(Ec) instead of 64
+- [x] q1 milestone buffs level by log10(Ec) instead of 64
 - I'm not even sure?
   - [ ] (?) Add a new level to cap ms: 16/24/36/48/64
     - Interval: 42/36/27/18/12
-  - [ ] (?) c level farming has diminishing returns?
+  - [ ] (?) q1 level farming has diminishing returns?
     - Does get better a bit with exp milestone
     - Theory loses that uniqueness
+  - [ ] (?) q1 level farming has limit at the end of story?
 
 - [x] rho dot is influenced by sum of all c values passed through
   - This way it can still stack after it ends, and income stops fluctuating

--- a/TODO.md
+++ b/TODO.md
@@ -12,10 +12,13 @@
   - Because once you've found what you love, the theory becomes just q1q2
   - Although, extra increments solve the setback from having to recover from overstaying pub
 
+- [ ] Apply LSR workload technique to history menu
+
 - [ ] Farm rate is weaker than before
   - (55/2) / (72/4) = 1.53
   - [x] For now, change into log2(Ec) / 10 -> 50.7% of rate before
   - Need more testing
+  - Currently: 76% (0.12 Eclog with 2, 8 q1)
 
 - [x] q1 turn into (2, 10) stepwise with low cost increment for activeness?
   - 2.09 or just 1.76? divisible by 11 this time

--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,9 @@
   - Although, extra increments solve the setback from having to recover from overstaying pub
 
 - [ ] Apply LSR workload technique to history menu
+- [x] q3 upgrades are too close together -> chaotic, too strong
+  - 17.6 -> 22
+- [ ] iOS UI bug that makes it super big and mess up the game entirely
 
 - [ ] Farm rate is weaker than before
   - (55/2) / (72/4) = 1.53

--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,11 @@
   - Because once you've found what you love, the theory becomes just q1q2
   - Although, extra increments solve the setback from having to recover from overstaying pub
 
+- [ ] Farm rate is stronger than before
+  - (55/2) / (72/4) = 1.53
+  - [x] For now, change into log2(Ec) / 10 -> half of rate before
+  - Need more testing
+
 - [x] q1 turn into (2, 10) stepwise with low cost increment for activeness?
   - 2.09 or just 1.76? divisible by 11 this time
 - [x] q2 return to 2^x

--- a/TODO.md
+++ b/TODO.md
@@ -13,9 +13,13 @@
   - Although, extra increments solve the setback from having to recover from overstaying pub
 
 - [ ] Apply LSR workload technique to history menu
+  - Scrapped - is actually slower than normal
 - [x] q3 upgrades are too close together -> chaotic, too strong
   - 17.6 -> 22
 - [ ] iOS UI bug that makes it super big and mess up the game entirely
+
+- [x] Balance later intervals to 22/14?
+  - Recovery too strong, making the buying process chaotic
 
 - [ ] Farm rate is weaker than before
   - (55/2) / (72/4) = 1.53

--- a/collatz.js
+++ b/collatz.js
@@ -74,7 +74,7 @@ let bigNumArray = (array) => array.map(x => BigNumber.from(x));
 
 // All balance parameters are aggregated for ease of access
 
-const borrowFactor = 0.1;
+const borrowFactor = .15;
 const q1Cost = new FirstFreeCost(new ExponentialCost(1, 1.76));
 const getq1BonusLevels = (bl) => bl ? (totalEclog + cLog) * borrowFactor : 0;
 const getq1 = (level) => Utils.getStepwisePowerSum(level + Math.floor(

--- a/collatz.js
+++ b/collatz.js
@@ -1058,7 +1058,9 @@ var getSecondaryEquation = () =>
 var getTertiaryEquation = () =>
 {
     let mStr = '';
-    let cStr = `\\\\(${cBigNum < 0 ? '' : '+\\,'}${cBigNum.toString(0)})`;
+    let cStr = '';
+    if(historyNumMode & 2 || c > 1e9 || c < -1e8)
+        cStr =  `\\\\(${cBigNum < 0 ? '' : '+\\,'}${cBigNum.toString(0)})`;
     if(reachedFirstPub)
         mStr = `t=${turns},&`;
     
@@ -1066,7 +1068,7 @@ var getTertiaryEquation = () =>
     let mcStr = `\\begin{matrix}${mStr}${csStr}
     \\end{matrix}`;
 
-    return `\\begin{array}{c}${mcStr}${c != 0n ? cStr : ''}\\end{array}`;
+    return `\\begin{array}{c}${mcStr}${cStr}\\end{array}`;
 }
 
 let createHistoryMenu = () =>

--- a/collatz.js
+++ b/collatz.js
@@ -101,7 +101,7 @@ const milestoneCost = new CompositeCost(2, new LinearCost(4.4, 4.4),
 new LinearCost(17.6, 8.8));
 
 const cLevelCap = [18, 32, 48, 66];
-const cooldown = [42, 30, 20, 12];
+const cooldown = [40, 30, 20, 12];
 
 const tauRate = 0.1;
 const pubExp = 3.01;

--- a/collatz.js
+++ b/collatz.js
@@ -968,7 +968,7 @@ var tick = (elapsedTime, multiplier) =>
     currency.value += dt * cSum.abs() * q1Term * q2Term * q3Term * bonus
     / rTerm;
 }
-/*
+
 var getEquationOverlay = () =>
 {
     let result = ui.createGrid
@@ -986,7 +986,7 @@ var getEquationOverlay = () =>
                 column: 0,
                 verticalTextAlignment: TextAlignment.START,
                 margin: new Thickness(6, 3),
-                text: getLoc('versionName')
+                text: getLoc('versionName'),
                 fontSize: 9,
                 textColor: Color.TEXT_MEDIUM
             }),
@@ -1018,7 +1018,7 @@ var getEquationOverlay = () =>
     });
     return result;
 }
-*/
+
 var getPrimaryEquation = () =>
 {
     let cStr = historyNumMode & 2 ? getShortBinaryString(c) :

--- a/collatz.js
+++ b/collatz.js
@@ -37,9 +37,9 @@ Warning: for spoiler purposes, it is ill-advised to
 share your sequences to new players.
 
 'If it's odd, take triple and one,
-If it's even, cut in two.
+If it's even, cut that in two.
 
-If you woke up with bread in hand,
+If you woke up with a bread in hand,
 what would you do?'`,
     };
 
@@ -104,11 +104,10 @@ const cLevelCap = [18, 32, 48, 66];
 const cooldown = [42, 30, 20, 12];
 
 const tauRate = 0.1;
-const pubExp = 2.7;
-const pubMult = 8;
-var getPublicationMultiplier = (tau) => tau.pow(pubExp) * pubMult;
+const pubExp = 3.01;
+var getPublicationMultiplier = (tau) => tau.pow(pubExp);
 var getPublicationMultiplierFormula = (symbol) =>
-`${pubMult}\\times{${symbol}}^{${pubExp}}`;
+`{${symbol}}^{${pubExp}}`;
 
 var freeze;
 var nudge, q1, q2, q3, extraInc;

--- a/collatz.js
+++ b/collatz.js
@@ -388,7 +388,7 @@ const historyLabel = ui.createLatexLabel
 const mimickFrame = ui.createFrame
 ({
     isVisible: false,
-    row: 1,
+    row: 0,
     column: 2,
     cornerRadius: 1,
     horizontalOptions: LayoutOptions.END,
@@ -421,7 +421,7 @@ const mimickFrame = ui.createFrame
 const mimickLabel = ui.createLatexLabel
 ({
     isVisible: false,
-    row: 1,
+    row: 0,
     column: 2,
     horizontalOptions: LayoutOptions.END,
     verticalOptions: LayoutOptions.END,
@@ -973,7 +973,7 @@ var getEquationOverlay = () =>
 {
     let result = ui.createGrid
     ({
-        rowDefinitions: ['1*', '1*'],
+        // rowDefinitions: ['1*', '1*'],
         columnDefinitions: ['1*', '2*', '1*'],
         children:
         [

--- a/collatz.js
+++ b/collatz.js
@@ -844,6 +844,7 @@ var init = () =>
         q1BorrowMs.description = Localization.getUpgradeIncCustomDesc(getLoc(
         'q1Level'), getLoc('Eclog'));
         q1BorrowMs.info = getLoc('EclogInfo');
+        q1BorrowMs.boughtOrRefunded = (_) => updateAvailability();
     }
     /* q1 exponent
     Standard exponent upgrade.
@@ -854,6 +855,7 @@ var init = () =>
         q1ExpInc);
         q1ExpMs.info = Localization.getUpgradeIncCustomExpInfo('q_1', q1ExpInc);
         q1ExpMs.boughtOrRefunded = (_) => theory.invalidateSecondaryEquation();
+        q1ExpMs.isAvailable = false;
     }
     /* q3 unlock
     Standard unlock.
@@ -866,7 +868,8 @@ var init = () =>
         {
             updateAvailability();
             theory.invalidateSecondaryEquation();
-        }
+        };
+        q3UnlockMs.isAvailable = false;
     }
 
     theory.createStoryChapter(0, getLoc('ch1Title'), getLoc('ch1Text'),
@@ -905,6 +908,8 @@ var updateAvailability = () =>
         reachedFirstPub = true;
     }
     extraIncPerma.isAvailable = freezePerma.level > 0;
+    extraInc.isAvailable = extraIncPerma.level > 0 &&
+    nudge.level == nudge.maxLevel;
     mimickPerma.isAvailable = extraIncPerma.level > 0;
     if(mimickPerma.level)
     {
@@ -913,8 +918,11 @@ var updateAvailability = () =>
     }
     q3.isAvailable = q3UnlockMs.level > 0;
     marathonBadge = theory.achievements[1].isUnlocked;
-    extraInc.isAvailable = extraIncPerma.level > 0 &&
-    nudge.level == nudge.maxLevel;
+    if(q1BorrowMs.level)
+    {
+        q1ExpMs.isAvailable = true;
+        q3UnlockMs.isAvailable = true;
+    }
 }
 
 var tick = (elapsedTime, multiplier) =>

--- a/collatz.js
+++ b/collatz.js
@@ -104,7 +104,7 @@ const cooldown = [42, 30, 20, 12];
 
 const tauRate = 0.1;
 const pubExp = 2.7;
-const pubMult = 8;
+const pubMult = 4;
 var getPublicationMultiplier = (tau) => tau.pow(pubExp) * pubMult;
 var getPublicationMultiplierFormula = (symbol) => `${pubMult}\\times{${symbol}}^{${pubExp}}`;
 

--- a/collatz.js
+++ b/collatz.js
@@ -100,7 +100,7 @@ const permaCosts = bigNumArray(['1e12', '1e22', '1e27', '1e56', '1e140',
 const milestoneCost = new CompositeCost(2, new LinearCost(4.4, 4.4),
 new LinearCost(17.6, 8.8));
 
-const cLevelCap = [18, 32, 48, 66];
+const cLevelCap = [20, 32, 48, 66];
 const cooldown = [40, 30, 22, 14];
 
 const tauRate = 0.1;
@@ -436,7 +436,7 @@ let getShortString = (n) =>
 {
     let s = n.toString();
     if(s.length > 9)
-        s = `${s.slice(0, 5)}...${s.slice(-3)}`;
+        s = `${s.slice(0, 4)}...${s.slice(-4)}`;
     return s;
 }
 
@@ -528,7 +528,7 @@ let getShorterString = (n) =>
 {
     let s = n.toString();
     if(s.length > 7)
-        s = `${s.slice(0, 3)}...${s.slice(-3)}`;
+        s = `${s.slice(0, 2)}...${s.slice(-4)}`;
     return s;
 }
 

--- a/collatz.js
+++ b/collatz.js
@@ -135,8 +135,8 @@ const locStrings =
 
         permaFreeze: '\\text{{the ability to freeze }}c',
         permaIncrement: `\\text{{extra in/decrements for }}c`,
-        permaIncrementInfo: `Dependent on {0}'s sign, and incurs a penalty ` +
-`on its level`,
+        permaIncrementInfo: `Dependent on {0}'s sign; incurs penalty ` +
+`on overall income`,
         permaMimick: 'Auto-nudge {0}',
         permaMimickInfo: 'Follows the last publication',
 
@@ -214,19 +214,19 @@ mechanical hand, programmable rhythms,
 foot-cranked toggle control, histographs.
 Even a toaster slot attached to the heat sink.
 
-What in the world could create this machine,
+Who in the world could create this machine,
 tailored to every nook of your nature,
 urging you to multiply your operations
 and get you busted?
-Some kind of vendetta.
 
 You see two signatures on the
 back of the machine.`,
 
         achNegativeTitle: 'Shrouded by Fog',
         achNegativeDesc: `Publish with an odd level of c and go negative.`,
-        achMarathonTitle: 'Annual Lothar-athon',
-        achMarathonDesc: 'Reach a c value of ±1e60. Reward: +1 to q3.',
+        achMarathonTitle: 'Local Marathon',
+        achMarathonDesc: 'Reach a c value of ±1e60 without using extra ' +
+        'levels. Reward: +1 to q3.',
         achSixNineTitle: 'I\'m proud of you.',
         achSixNineDesc: 'Reach a c value of 69.',
 
@@ -872,7 +872,8 @@ var init = () =>
     theory.createAchievement(0, undefined, getLoc('achNegativeTitle'),
     getLoc('achNegativeDesc'), () => cBigNum < 0);
     theory.createAchievement(1, undefined, getLoc('achMarathonTitle'),
-    getLoc('achMarathonDesc'), () => cBigNum.abs() >= 1e60, () => c == 0n ? 0 :
+    getLoc('achMarathonDesc'), () => cBigNum.abs() >= 1e60 &&
+    extraInc.level == 0, () => c == 0n ? 0 :
     cBigNum.abs().log10().toNumber() / 60);
     theory.createAchievement(2, undefined, getLoc('achSixNineTitle'),
     getLoc('achSixNineDesc'), () => c == 69n);

--- a/collatz.js
+++ b/collatz.js
@@ -103,7 +103,7 @@ const cLevelCap = [18, 32, 48, 66];
 const cooldown = [42, 30, 20, 12];
 
 const tauRate = 0.1;
-const pubExp = 2.4;
+const pubExp = 2.7;
 var getPublicationMultiplier = (tau) => tau.pow(pubExp);
 var getPublicationMultiplierFormula = (symbol) => `{${symbol}}^{${pubExp}}`;
 
@@ -143,7 +143,7 @@ const locStrings =
         cLevelth: `1/{{{0}}}^\\text{{{{th}}}}\\text{{{{ of }}}}c
         \\text{{{{ level}}}}`,
         Eclog: '\\log_{10}\\Sigma\\,c\\text{{{{ (cumulative)}}}}',
-        EclogInfo: 'Stacks additively across publications',
+        EclogInfo: 'Stacks across publications',
         cLevelCap: 'c\\text{{ level cap}}',
         cooldown: '\\text{{interval}}',
         cooldownInfo: 'Interval',

--- a/collatz.js
+++ b/collatz.js
@@ -98,7 +98,7 @@ const milestoneCost = new CompositeCost(2, new LinearCost(4.4, 4.4),
 new LinearCost(17.6, 8.8));
 
 const cLevelCap = [20, 32, 48, 66];
-const cooldown = [40, 30, 22, 14];
+const cooldown = [36, 28, 20, 14];
 
 const tauRate = 0.1;
 const pubExp = 3.01;

--- a/collatz.js
+++ b/collatz.js
@@ -831,9 +831,6 @@ var init = () =>
         q1BorrowMs.description = Localization.getUpgradeIncCustomDesc(getLoc(
         'q1Level'), Localization.format(getLoc('Eclog'), borrowFactor));
         q1BorrowMs.info = getLoc('EclogInfo');
-        q1BorrowMs.boughtOrRefunded = (_) => updateAvailability();
-        q1BorrowMs.canBeRefunded = (_) => q1ExpMs.level == 0 &&
-        q3UnlockMs.level == 0;
     }
     /* q1 exponent
     Standard exponent upgrade.
@@ -844,7 +841,6 @@ var init = () =>
         q1ExpInc);
         q1ExpMs.info = Localization.getUpgradeIncCustomExpInfo('q_1', q1ExpInc);
         q1ExpMs.boughtOrRefunded = (_) => theory.invalidateSecondaryEquation();
-        q1ExpMs.isAvailable = false;
     }
     /* q3 unlock
     Standard unlock.
@@ -858,7 +854,6 @@ var init = () =>
             updateAvailability();
             theory.invalidateSecondaryEquation();
         };
-        q3UnlockMs.isAvailable = false;
     }
 
     theory.createStoryChapter(0, getLoc('ch1Title'), getLoc('ch1Text'),
@@ -905,8 +900,8 @@ var updateAvailability = () =>
         mimickFrame.isVisible = true;
         mimickLabel.isVisible = true;
     }
-    q1ExpMs.isAvailable = q1BorrowMs.level > 0;
-    q3UnlockMs.isAvailable = q1BorrowMs.level > 0;
+    q1ExpMs.isAvailable = theory.milestonesTotal > 1;
+    q3UnlockMs.isAvailable = theory.milestonesTotal > 1;
     q3.isAvailable = q3UnlockMs.level > 0;
     marathonBadge = theory.achievements[1].isUnlocked;
 }

--- a/collatz.js
+++ b/collatz.js
@@ -973,7 +973,6 @@ var getEquationOverlay = () =>
 {
     let result = ui.createGrid
     ({
-        verticalOptions: LayoutOptions.FILL,
         rowDefinitions: ['1*', '1*'],
         columnDefinitions: ['1*', '2*', '1*'],
         children:

--- a/collatz.js
+++ b/collatz.js
@@ -968,7 +968,7 @@ var tick = (elapsedTime, multiplier) =>
     currency.value += dt * cSum.abs() * q1Term * q2Term * q3Term * bonus
     / rTerm;
 }
-
+/*
 var getEquationOverlay = () =>
 {
     let result = ui.createGrid
@@ -986,8 +986,7 @@ var getEquationOverlay = () =>
                 column: 0,
                 verticalTextAlignment: TextAlignment.START,
                 margin: new Thickness(6, 3),
-                text: getLoc('versionName')/* +
-                Utils.getMath(getLoc('changeLog'))*/,
+                text: getLoc('versionName')
                 fontSize: 9,
                 textColor: Color.TEXT_MEDIUM
             }),
@@ -1019,7 +1018,7 @@ var getEquationOverlay = () =>
     });
     return result;
 }
-
+*/
 var getPrimaryEquation = () =>
 {
     let cStr = historyNumMode & 2 ? getShortBinaryString(c) :

--- a/collatz.js
+++ b/collatz.js
@@ -87,7 +87,7 @@ const getq1Exponent = (level) => 1 + q1ExpInc * level;
 const q2Cost = new ExponentialCost(2.2e7, 11);
 const getq2 = (level) => BigNumber.TWO.pow(level);
 
-const q3Cost = new ExponentialCost(BigNumber.from('1e270'), 17.6);
+const q3Cost = new ExponentialCost(BigNumber.from('1e270'), 22);
 const getq3 = (level) => BigNumber.THREE.pow(level) + (marathonBadge ? 1 : 0);
 
 const getr = (level) => Utils.getStepwisePowerSum(level, 2, 6, 0);

--- a/collatz.js
+++ b/collatz.js
@@ -104,7 +104,7 @@ const cooldown = [42, 30, 20, 12];
 
 const tauRate = 0.1;
 const pubExp = 2.7;
-const pubMult = 4;
+const pubMult = 8;
 var getPublicationMultiplier = (tau) => tau.pow(pubExp) * pubMult;
 var getPublicationMultiplierFormula = (symbol) => `${pubMult}\\times{${symbol}}^{${pubExp}}`;
 

--- a/collatz.js
+++ b/collatz.js
@@ -76,7 +76,7 @@ let bigNumArray = (array) => array.map(x => BigNumber.from(x));
 
 const borrowFactor = 0.1;
 const q1Cost = new FirstFreeCost(new ExponentialCost(1, 1.76));
-const getq1BonusLevels = (bl) => (totalEclog + cLog) * borrowFactor * bl;
+const getq1BonusLevels = (bl) => bl ? (totalEclog + cLog) * borrowFactor : 0;
 const getq1 = (level) => Utils.getStepwisePowerSum(level + Math.floor(
 getq1BonusLevels(q1BorrowMs.level)), 2, 10, 0);
 
@@ -87,7 +87,7 @@ const getq1Exponent = (level) => 1 + q1ExpInc * level;
 const q2Cost = new ExponentialCost(2.2e7, 11);
 const getq2 = (level) => BigNumber.TWO.pow(level);
 
-const q3Cost = new ExponentialCost(BigNumber.from('1e270'), 18);
+const q3Cost = new ExponentialCost(BigNumber.from('1e270'), 17.6);
 const getq3 = (level) => BigNumber.THREE.pow(level) + (marathonBadge ? 1 : 0);
 
 const getr = (level) => Utils.getStepwisePowerSum(level, 2, 6, 0);
@@ -230,6 +230,7 @@ back of the machine.`,
         achSixNineTitle: 'I\'m proud of you.',
         achSixNineDesc: 'Reach a c value of 69.',
 
+        btnClose: 'Close',
         btnSave: 'Save',
         btnIndexingMode: ['Indexing: Turns', 'Indexing: Levels'],
         btnNotationMode: ['Notation: Digits', 'Notation: Scientific'],
@@ -1187,10 +1188,9 @@ let createHistoryMenu = () =>
             lastPubHistory
         ]
     });
-    let tmpPreserve = preserveLastHistory;
     let preserveSwitch = ui.createSwitch
     ({
-        isToggled: tmpPreserve,
+        isToggled: preserveLastHistory,
         row: 0,
         column: 1,
         horizontalOptions: LayoutOptions.END,
@@ -1200,8 +1200,8 @@ let createHistoryMenu = () =>
             e.type == TouchType.LONGPRESS_RELEASED)
             {
                 Sound.playClick();
-                tmpPreserve = !tmpPreserve;
-                preserveSwitch.isToggled = tmpPreserve;
+                preserveLastHistory = !preserveLastHistory;
+                preserveSwitch.isToggled = preserveLastHistory;
             }
         }
     });
@@ -1262,11 +1262,10 @@ let createHistoryMenu = () =>
                 }),
                 ui.createButton
                 ({
-                    text: getLoc('btnSave'),
+                    text: getLoc('btnClose'),
                     onClicked: () =>
                     {
                         Sound.playClick();
-                        preserveLastHistory = tmpPreserve;
                         menu.hide();
                     }
                 })

--- a/collatz.js
+++ b/collatz.js
@@ -74,11 +74,11 @@ let bigNumArray = (array) => array.map(x => BigNumber.from(x));
 
 // All balance parameters are aggregated for ease of access
 
-const borrowFactor = .15;
+const borrowFactor = .12;
 const q1Cost = new FirstFreeCost(new ExponentialCost(1, 1.76));
 const getq1BonusLevels = (bl) => bl ? (totalEclog + cLog) * borrowFactor : 0;
 const getq1 = (level) => Utils.getStepwisePowerSum(level + Math.floor(
-getq1BonusLevels(q1BorrowMs.level)), 2, 10, 0);
+getq1BonusLevels(q1BorrowMs.level)), 2, 8, 0);
 
 const q1ExpInc = 0.02;
 const q1ExpMaxLevel = 4;
@@ -660,7 +660,9 @@ var init = () =>
         nudge.maxLevel = cLevelCap[0];
     }
     /* q1 (c1 prior to 0.06)
-    Standard (2, 10) stepwise power.
+    Non-standard (2, 8) stepwise power.
+    Ratios against q2: 4.5, 5, 5.5, 6, 6.5, 7, 7.5, 8
+    Ratios against q3: 6, 6.67, 7.33, 8, 8.67, 9.33, 10, 10.67
     */
     {
         let getLevelPrefix = (level) => level ? `_{(+

--- a/collatz.js
+++ b/collatz.js
@@ -175,14 +175,9 @@ It's certainly interesting: even though it's
 bound to fall, if you cheat by even just a little bit,
 the outcome can get a lot better.
 
-Impressed by your work, a professor offers you
-an internship in his research lab.
 Occasionally, you can be heard in the lab,
 giggling with some of your online chat friends,
-who call you: the CEO of Nudge.
-
-But inside, you are afraid.
-It's bound to fall.`,
+who call you: the CEO of Nudge.`,
 
         ch3Title: 'Escalations',
         ch3Text: `Eventually, a colleague of yours has come to

--- a/collatz.js
+++ b/collatz.js
@@ -101,7 +101,7 @@ const milestoneCost = new CompositeCost(2, new LinearCost(4.4, 4.4),
 new LinearCost(17.6, 8.8));
 
 const cLevelCap = [18, 32, 48, 66];
-const cooldown = [40, 30, 20, 12];
+const cooldown = [40, 30, 22, 14];
 
 const tauRate = 0.1;
 const pubExp = 3.01;

--- a/collatz.js
+++ b/collatz.js
@@ -900,8 +900,8 @@ var updateAvailability = () =>
         mimickFrame.isVisible = true;
         mimickLabel.isVisible = true;
     }
-    q1ExpMs.isAvailable = theory.milestonesTotal > 1;
-    q3UnlockMs.isAvailable = theory.milestonesTotal > 1;
+    q1ExpMs.isAvailable = theory.milestonesTotal > 2;
+    q3UnlockMs.isAvailable = theory.milestonesTotal > 2;
     q3.isAvailable = q3UnlockMs.level > 0;
     marathonBadge = theory.achievements[1].isUnlocked;
 }

--- a/collatz.js
+++ b/collatz.js
@@ -33,9 +33,6 @@ var getDescription = (language) =>
 `A puzzle revolving around trying to counteract the even clause of the ` +
 `Collatz conjecture.
 
-Warning: for spoiler purposes, it is ill-advised to
-share your sequences to new players.
-
 'If it's odd, take triple and one,
 If it's even, cut that in two.
 

--- a/collatz.js
+++ b/collatz.js
@@ -15,12 +15,12 @@ import { Easing } from '../api/ui/properties/Easing';
 import { ScrollOrientation } from '../api/ui/properties/ScrollOrientation';
 import { TextAlignment } from '../api/ui/properties/TextAlignment';
 
-var id = 'collatz_conjecture_b';
+var id = 'collatz_conjecture';
 var getName = (language) =>
 {
     let names =
     {
-        en: 'Colla🅱z Con🅱ecture',
+        en: 'Collatz Conjecture',
     };
 
     return names[language] || names.en;
@@ -1383,9 +1383,10 @@ var setInternalState = (stateStr) =>
         cBigNum = BigNumber.from(c);
     }
     if('cSum' in state)
+    {
         cSum = BigNumber.fromBase64String(state.cSum);
-
-    cLog = cSum.max(BigNumber.ONE).log2().toNumber();
+        cLog = cSum.max(BigNumber.ONE).log2().toNumber();
+    }
     if('totalEclog' in state)
         totalEclog = state.totalEclog;
 

--- a/collatz.js
+++ b/collatz.js
@@ -45,9 +45,9 @@ what would you do?'`,
 
     return descs[language] || descs.en;
 }
-var authors = 'propfeds#5988\n\nThanks to:\nCipher#9599, the original ' +
-'suggester\nXLII#0042, a computer pretending to be a normal player, acting ' +
-'at the speed of light';
+var authors = 'propfeds\n\nThanks to:\nCipher#9599, the original suggester\n' +
+'XLII#0042, a computer pretending to be a normal player, acting at the speed ' +
+'of light';
 var version = 0.08;
 
 let turns = 0;
@@ -87,7 +87,7 @@ const getq1Exponent = (level) => 1 + q1ExpInc * level;
 const q2Cost = new ExponentialCost(2.2e7, 11);
 const getq2 = (level) => BigNumber.TWO.pow(level);
 
-const q3Cost = new ExponentialCost(BigNumber.from('1e270'), 22);
+const q3Cost = new ExponentialCost(BigNumber.from('1e272'), Math.log2(1e8));
 const getq3 = (level) => BigNumber.THREE.pow(level) + (marathonBadge ? 1 : 0);
 
 const getr = (level) => Utils.getStepwisePowerSum(level, 2, 6, 0);

--- a/collatz.js
+++ b/collatz.js
@@ -104,8 +104,9 @@ const cooldown = [42, 30, 20, 12];
 
 const tauRate = 0.1;
 const pubExp = 2.7;
-var getPublicationMultiplier = (tau) => tau.pow(pubExp);
-var getPublicationMultiplierFormula = (symbol) => `{${symbol}}^{${pubExp}}`;
+const pubMult = 8;
+var getPublicationMultiplier = (tau) => tau.pow(pubExp) * pubMult;
+var getPublicationMultiplierFormula = (symbol) => `${pubMult}\\times{${symbol}}^{${pubExp}}`;
 
 var freeze;
 var nudge, q1, q2, q3, extraInc;
@@ -143,7 +144,7 @@ const locStrings =
         cLevelth: `1/{{{0}}}^\\text{{{{th}}}}\\text{{{{ of }}}}c
         \\text{{{{ level}}}}`,
         Eclog: '\\log_{10}\\Sigma\\,c\\text{{{{ (cumulative)}}}}',
-        EclogInfo: 'Stacks across publications',
+        EclogInfo: 'Stacks additively across publications',
         cLevelCap: 'c\\text{{ level cap}}',
         cooldown: '\\text{{interval}}',
         cooldownInfo: 'Interval',

--- a/collatz.js
+++ b/collatz.js
@@ -92,7 +92,7 @@ const getq3 = (level) => BigNumber.THREE.pow(level) + (marathonBadge ? 1 : 0);
 const getr = (level) => Utils.getStepwisePowerSum(level, 2, 6, 0);
 const getrPenalty = (level) => BigNumber.TWO.pow(getr(level));
 
-const permaCosts = bigNumArray(['1e12', '1e22', '1e31', '1e58', '1e126',
+const permaCosts = bigNumArray(['1e12', '1e22', '1e27', '1e56', '1e140',
 '1e301']);
 // 44, 88, 176, 264, 352, 440, 528, 616, 704
 // cap cap  cap  bor  q3  exp  exp  exp  exp
@@ -941,7 +941,7 @@ var tick = (elapsedTime, multiplier) =>
                 c /= 2n;
             cBigNum = BigNumber.from(c);
 
-            if(nudge.level > totalIncLevel)
+            if(nudge.level > totalIncLevel % 2)
                 ++turns;
 
             if(mimickLastHistory)

--- a/collatz.js
+++ b/collatz.js
@@ -753,6 +753,7 @@ var init = () =>
     theory.createPublicationUpgrade(0, currency, permaCosts[0]);
     theory.createBuyAllUpgrade(1, currency, permaCosts[1]);
     theory.createAutoBuyerUpgrade(2, currency, permaCosts[2]);
+    theory.autoBuyerUpgrade.bought = (_) => updateAvailability();
     /* Unlocks freeze
     Shame that you unlock such a useful tool really late.
     */

--- a/collatz.js
+++ b/collatz.js
@@ -120,7 +120,7 @@ const locStrings =
 {
     en:
     {
-        versionName: 'v0.0B, Work in\\\\Progress',
+        versionName: 'v0.08 (WIP)',
         longTick: 'Tick: {0}s',
 
         historyDesc: `\\begin{{array}}{{c}}\\text{{History}}\\\\{{{0}}}/{{{1}}}

--- a/collatz.js
+++ b/collatz.js
@@ -145,7 +145,7 @@ const locStrings =
         cLevelth: `1/{{{0}}}^\\text{{{{th}}}}\\text{{{{ of }}}}c
         \\text{{{{ level}}}}`,
         Eclog: '{{{0}}}\\times\\log_{{2}}\\Sigma\\,c\\text{{ (cumulative)}}',
-        EclogInfo: 'Stacks additively across publications',
+        EclogInfo: 'Stacks passively across publications',
         cLevelCap: 'c\\text{{ level cap}}',
         cooldown: '\\text{{interval}}',
         cooldownInfo: 'Interval',


### PR DESCRIPTION
Version 0.0B: Transforming the entire theory.
- Publication multiplier: tau^4 → tau^3.01 (good number!)
- q1: 3.01 cost (2, 10) stepwise → 1.76 cost (2, 8) stepwise
- q2: 3^x → 2^x
- q3: New 3^x variable unlocked with milestone!
- Extra increments: Now divides income instead of decreasing c level

- Overall income: Now multiplies by the sum of c values instead of the current
- q1 borrow: Now stacks using log2(sum of c) instead of a flat value per pub
- Adjusted perma costs to 12, 22, 27, 56, 140, 301
- Adjusted milestones to 44, 88, 176, 264, 352, 440, 528, 616, 704
- Adjusted interval to 20, 32, 48, 64
- Adjusted c cap to 36, 28, 20, 14

Other changes:
- No longer stacks up c levels in the UI (except for keeping 1 when odd)