### PR TITLE
v0.10

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,8 +5,10 @@
 - Ask Gilles:
   - [ ] Make a bonus levels function like perma levels from stars
 
-- [ ] Issue: End-game reset grind
-  - Add t term?
+- [ ] Add a pub div to dampen first pub?
+
+- Issue: End-game reset grind
+  - [x] Add t term?
 
 - [ ] Issue: extra increments are not interesting currently
   - Because it sets back progress for not much short-term benefit

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,20 @@
 - [x] Extra increments are bought with Ec
   - [ ] Late game Ec no longer resets on publish
 
+- [ ] Explain 2nd stone in Pi product?
+- [x] Change log2 to log10
+
+- [x] Increase 2nd milestone rate
+- [x] Reset grants levels
+- [ ] Auto-nudge grants auto-reset at a specific amount of turns
+
+- [ ] Preserve bugged, not working?
+
+- [ ] Auto-publish
+  - Settings:
+    - Multiplier threshold (makes you think when to pub)
+    - Turn threshold (too easy)
+
 - Ask Gilles:
   - [ ] Make a bonus levels function like perma levels from stars
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,8 @@
 
 ## In consideration
 
-- [ ] Extra increments are bought with Ec
+- [x] Extra increments are bought with Ec
+  - [ ] Late game Ec no longer resets on publish
 
 - Ask Gilles:
   - [ ] Make a bonus levels function like perma levels from stars

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,8 @@
 
 ## In consideration
 
+- [ ] Extra increments are bought with Ec
+
 - Ask Gilles:
   - [ ] Make a bonus levels function like perma levels from stars
 

--- a/collatz.js
+++ b/collatz.js
@@ -163,7 +163,7 @@ const locStrings =
         cLevel: '1/{{{0}}}\\text{{{{ of }}}}c\\text{{{{ level}}}}',
         cLevelth: `1/{{{0}}}^\\text{{{{th}}}}\\text{{{{ of }}}}c
         \\text{{{{ level}}}}`,
-        Eclog: `\\log_{{2}}\\Pi(\\Sigma c)\\text{{ (across pubs)}}`,
+        Eclog: `\\log_{{10}}\\Pi(\\Sigma c)\\text{{ (across pubs)}}`,
         EclogInfo: 'Accumulates across publications (max {0})',
         cLevelCap: 'c\\text{{ level cap}}',
         cooldown: '\\text{{interval}}',

--- a/collatz.js
+++ b/collatz.js
@@ -1169,7 +1169,7 @@ var getSecondaryEquation = () =>
     let result = `\\begin{matrix}\\dot{\\rho}=t{\\mkern 1mu}q_1
     ${q1ExpMs.level > 0 ?`^{${getq1Exponent(q1ExpMs.level)}}` : ''}q_2
     ${q3UnlockMs.level > 0 ? 'q_3' : ''}\\times${EcStr}\\\\\\\\
-    ${theory.latexSymbol}=\\max{\\rho}^{0.1}\\end{matrix}`;
+    ${theory.latexSymbol}=\\max{\\rho}^{${tauRate}}\\end{matrix}`;
 
     return result;
 }

--- a/collatz.js
+++ b/collatz.js
@@ -58,6 +58,7 @@ let totalEclog = 0;
 let totalIncLevel = 0;
 let history = {};
 let lastHistory;
+let lastHistoryStrings = [[], []];
 let writeHistory = true;
 let historyNumMode = 0;
 let historyIdxMode = 1;
@@ -1191,8 +1192,6 @@ let createHistoryMenu = () =>
         historyIdxMode ^= 1;
         currentPubHistory.text = getSequence(history, historyNumMode,
         historyIdxMode);
-        lastPubHistory.text = getSequence(lastHistory, historyNumMode,
-        historyIdxMode);
         toggleIdxButton.text = getLoc('btnIndexingMode')[historyIdxMode & 1];
     }
     let toggleIdxButton = ui.createButton
@@ -1209,8 +1208,6 @@ let createHistoryMenu = () =>
     {
         historyNumMode = historyNumMode ^ 1;
         currentPubHistory.text = getSequence(history, historyNumMode,
-        historyIdxMode);
-        lastPubHistory.text = getSequence(lastHistory, historyNumMode,
         historyIdxMode);
         toggleNumButton.text = getLoc('btnNotationMode')[historyNumMode & 1];
     };
@@ -1236,7 +1233,13 @@ let createHistoryMenu = () =>
     ({
         row: 2,
         column: 1,
-        text: getSequence(lastHistory, historyNumMode, historyIdxMode),
+        text: () =>
+        {
+            if(!lastHistoryStrings[historyIdxMode][historyNumMode])
+                lastHistoryStrings[historyIdxMode][historyNumMode] =
+                getSequence(lastHistory, historyNumMode, historyIdxMode);
+            return lastHistoryStrings[historyIdxMode][historyNumMode];
+        },
         margin: new Thickness(3, 0, 0, 0),
         horizontalTextAlignment: TextAlignment.CENTER,
     });
@@ -1397,7 +1400,10 @@ var prePublish = () =>
     totalEclog += cLog;
     totalIncLevel += nudge.level;
     if(!preserveLastHistory)
+    {
         lastHistory = history;
+        lastHistoryStrings = [[], []];
+    }
     lastHistoryLength = Object.keys(lastHistory).length;
 }
 
@@ -1478,6 +1484,7 @@ var getInternalState = () => JSON.stringify
     totalIncLevel: totalIncLevel,
     history: history,
     lastHistory: lastHistory,
+    lastHistoryStrings: lastHistoryStrings,
     historyNumMode: historyNumMode,
     historyIdxMode: historyIdxMode,
     mimickLastHistory: mimickLastHistory,
@@ -1540,6 +1547,8 @@ var setInternalState = (stateStr) =>
         if(mimickLastHistory)
             nextNudge = binarySearch(LHObj, turns);
     }
+    if('lastHistoryStrings' in state)
+        lastHistoryStrings = state.lastHistoryStrings;
     if('historyNumMode' in state)
         historyNumMode = state.historyNumMode;
     if('historyIdxMode' in state)

--- a/collatz.js
+++ b/collatz.js
@@ -70,7 +70,7 @@ let bigNumArray = (array) => array.map(x => BigNumber.from(x));
 
 // All balance parameters are aggregated for ease of access
 
-const borrowFactor = .12;
+const borrowFactor = .15;
 const borrowCap = 9232;
 const q1Cost = new FirstFreeCost(new ExponentialCost(1, 1.6));
 const getq1BonusLevels = (bl) => bl ? Math.min((totalEclog + cLog) *

--- a/collatz.js
+++ b/collatz.js
@@ -1320,7 +1320,7 @@ let createHistoryMenu = () =>
                 // }),
                 ui.createScrollView
                 ({
-                    // heightRequest: ui.screenHeight * 0.32,
+                    heightRequest: ui.screenHeight * 0.32,
                     content: historyGrid,
                     orientation: ScrollOrientation.BOTH
                 }),

--- a/collatz.js
+++ b/collatz.js
@@ -137,7 +137,7 @@ const locStrings =
 {
     en:
     {
-        versionName: 'v0.10, WIP',
+        versionName: 'v0.10',
         longTick: 'Tick: {0}s',
 
         history: 'History',

--- a/collatz.js
+++ b/collatz.js
@@ -116,7 +116,7 @@ var freezePerma, extraIncPerma, mimickPerma;
 var freeEclog;
 var cooldownMs, q1BorrowMs, q1ExpMs, q3UnlockMs;
 
-var currency;
+var currency, EcCurrency;
 
 var finalChapter;
 
@@ -671,6 +671,7 @@ let binarySearch = (arr, target) =>
 var init = () =>
 {
     currency = theory.createCurrency();
+    EcCurrency = theory.createCurrency('Σc', '\\Sigma c');
     /* Freeze
     Freeze c's value and the timer in place, which allows for idling. This will
     become more important later on, and also helps with farming c levels.
@@ -1074,6 +1075,7 @@ var tick = (elapsedTime, multiplier) =>
 
     currency.value += dt * tTerm * cSum.abs() * q1Term * q2Term * q3Term * bonus
     / rTerm;
+    EcCurrency.value = cSum;
 }
 
 var getEquationOverlay = () =>
@@ -1157,16 +1159,19 @@ var getSecondaryEquation = () =>
 
 var getTertiaryEquation = () =>
 {
-    let mStr = `t=${turns},&`;
     let cStr = '';
     if(historyNumMode & 2 || c > 1e9 || c < -1e8)
-        cStr =  `\\\\(${cBigNum < 0 ? '' : '+\\,'}${cBigNum.toString(0)})`;
-    
-    let csStr = `\\Sigma c=${cSum.toString(0)}`;
-    let mcStr = `\\begin{matrix}${mStr}${csStr}
-    \\end{matrix}`;
+        cStr = `,&${cBigNum < 0 ? '' : '+\\,'}${cBigNum.toString(0)}`;
+    return `begin{matrix}t=${turns}${cStr}`;
 
-    return `\\begin{array}{c}${mcStr}${cStr}\\end{array}`;
+    let tStr = `t=${turns},&`;
+    if(historyNumMode & 2 || c > 1e9 || c < -1e8)
+        cStr =  `\\\\(${cBigNum < 0 ? '' : '+\\,'}${cBigNum.toString(0)})`;
+
+    let csStr = `\\Sigma c=${cSum.toString(0)}`;
+
+    return `\\begin{array}{c}\\begin{matrix}${tStr}${csStr}\\end{matrix}
+    ${cStr}\\end{array}`;
 }
 
 let createHistoryMenu = () =>

--- a/collatz.js
+++ b/collatz.js
@@ -671,7 +671,7 @@ let binarySearch = (arr, target) =>
 var init = () =>
 {
     currency = theory.createCurrency();
-    EcCurrency = theory.createCurrency(' Σc', '\\Sigma c');
+    EcCurrency = theory.createCurrency(' Σc', ' \\Sigma c');
     /* Freeze
     Freeze c's value and the timer in place, which allows for idling. This will
     become more important later on, and also helps with farming c levels.

--- a/collatz.js
+++ b/collatz.js
@@ -115,14 +115,12 @@ new CompositeCost(9, new LinearCost(24, 12), new LinearCost(120, 12)));
 const cLevelCap = [12, 20, 28, 36, 48];
 const cooldown = [36, 32, 28, 24, 18];
 
-const tauRate = 0.2;
+const tauRate = 0.1;
 const pubExp = 3.01;
-const CtRate = 2;
-const pubExpAfterRate = pubExp / CtRate;
 // const pubMult = 8;
-var getPublicationMultiplier = (tau) => tau.pow(pubExpAfterRate);
+var getPublicationMultiplier = (tau) => tau.pow(pubExp);
 var getPublicationMultiplierFormula = (symbol) =>
-`{${symbol}}^{${pubExp}/${CtRate}}`;
+`{${symbol}}^{${pubExp}}`;
 
 var freeze;
 var nudge, q1, q2, q3, extraInc;

--- a/collatz.js
+++ b/collatz.js
@@ -45,7 +45,7 @@ what would you do?'`,
 var authors = 'propfeds\n\nThanks to:\nCipher#9599, the original suggester\n' +
 'XLII#0042, a computer pretending to be a normal player, acting at the speed ' +
 'of light';
-var version = 0.09;
+var version = 0.10;
 
 let haxEnabled = false;
 let turns = 0;
@@ -72,17 +72,17 @@ let bigNumArray = (array) => array.map(x => BigNumber.from(x));
 
 const borrowFactor = .15;
 const borrowCap = 9232;
-const q1Cost = new FirstFreeCost(new ExponentialCost(1, 1.6));
+const q1Cost = new FirstFreeCost(new ExponentialCost(1, 1.5));
 const getq1BonusLevels = (bl) => bl ? Math.min((totalEclog + cLog) *
 borrowFactor, borrowCap) : 0;
 const getq1 = (level) => Utils.getStepwisePowerSum(level + Math.floor(
-getq1BonusLevels(q1BorrowMs.level)), 2, 8, 0);
+getq1BonusLevels(q1BorrowMs.level)), 2, 10, 0);
 
 const q1ExpInc = 0.02;
 const q1ExpMaxLevel = 6;
 const getq1Exponent = (level) => 1 + q1ExpInc * level;
 
-const q2Cost = new ExponentialCost(2.2e7, 6.4);
+const q2Cost = new ExponentialCost(2.2e7, 6);
 const getq2 = (level) => BigNumber.TWO.pow(level);
 
 const q3Cost = new ExponentialCost(BigNumber.from('1e301'), Math.log2(1e3));
@@ -92,22 +92,24 @@ const extraIncCost = new ExponentialCost(1e40, Math.log2(5));
 const getr = (level) => Utils.getStepwisePowerSum(level, 2, 6, 0);
 const getrPenalty = (level) => BigNumber.FOUR.pow(getr(level));
 
-const permaCosts = bigNumArray(['1e12', '1e22', '1e27', '1e56', '1e1200',
-'1e100']);
-// 44, 88, 176, 264, 352, 440, 528, 616, 704
+const permaCosts = bigNumArray(['1e12', '1e20', '1e24', '1e44', '1e1200',
+'1e80']);
+// 30, 60, 120, 180, 240, 300, 360, 420, 480
 // cap cap  cap  bor  q3  exp  exp  exp  exp
-const milestoneCost = new CompositeCost(2, new LinearCost(4.4, 4.4),
-new CompositeCost(9, new LinearCost(17.6, 8.8), new LinearCost(110, 13.2)));
+const milestoneCost = new CompositeCost(2, new LinearCost(6, 6),
+new CompositeCost(9, new LinearCost(24, 12), new LinearCost(120, 12)));
 
-const cLevelCap = [20, 28, 36, 48];
-const cooldown = [36, 30, 24, 18];
+const cLevelCap = [12, 20, 28, 36, 48];
+const cooldown = [36, 32, 28, 24, 18];
 
-const tauRate = 0.1;
+const tauRate = 0.2;
 const pubExp = 3.01;
+const CtRate = 2;
+const pubExpAfterRate = pubExp / CtRate;
 // const pubMult = 8;
-var getPublicationMultiplier = (tau) => tau.pow(pubExp);
+var getPublicationMultiplier = (tau) => tau.pow(pubExpAfterRate);
 var getPublicationMultiplierFormula = (symbol) =>
-`{${symbol}}^{${pubExp}}`;
+`{${symbol}}^{${pubExp}/${CtRate}}`;
 
 var freeze;
 var nudge, q1, q2, q3, extraInc;
@@ -123,7 +125,7 @@ const locStrings =
 {
     en:
     {
-        versionName: 'v0.09',
+        versionName: 'v0.10, WIP',
         longTick: 'Tick: {0}s',
 
         history: 'History',
@@ -670,7 +672,7 @@ let binarySearch = (arr, target) =>
 var init = () =>
 {
     currency = theory.createCurrency();
-    EcCurrency = theory.createCurrency('Σc', '\\Sigma c');
+    // EcCurrency = theory.createCurrency('Σc', '\\Sigma c');
     /* Freeze
     Freeze c's value and the timer in place, which allows for idling. This will
     become more important later on, and also helps with farming c levels.
@@ -783,7 +785,7 @@ var init = () =>
         let getDesc = (level) => `c\\leftarrow c
         ${c < 0n ? '-' : '+'}1;\\enspace r=${getr(level).toString(0)}`;
         let getInfo = (level) => `r=${getr(level).toString(0)}`;
-        extraInc = theory.createUpgrade(4, EcCurrency, extraIncCost);
+        extraInc = theory.createUpgrade(4, currency, extraIncCost);
         extraInc.getDescription = () => Utils.getMath(getDesc(
         extraInc.level));
         extraInc.getInfo = (amount) => Utils.getMathTo(getInfo(extraInc.level),
@@ -808,6 +810,10 @@ var init = () =>
         extraInc.isAvailable = false;
     }
 
+    theory.createPublicationUpgrade(0, currency, permaCosts[0]);
+    theory.createBuyAllUpgrade(1, currency, permaCosts[1]);
+    theory.createAutoBuyerUpgrade(2, currency, permaCosts[2]);
+    theory.autoBuyerUpgrade.bought = (_) => updateAvailability();
     /* Toggle base
     QoL!
     */
@@ -825,10 +831,6 @@ var init = () =>
             theory.invalidateTertiaryEquation();
         }
     }
-    theory.createPublicationUpgrade(0, currency, permaCosts[0]);
-    theory.createBuyAllUpgrade(1, currency, permaCosts[1]);
-    theory.createAutoBuyerUpgrade(2, currency, permaCosts[2]);
-    theory.autoBuyerUpgrade.bought = (_) => updateAvailability();
     /* Unlocks freeze
     Shame that you unlock such a useful tool really late.
     */
@@ -1008,8 +1010,9 @@ var updateAvailability = () =>
     extraInc.isAvailable = extraIncPerma.level > 0 &&
     nudge.level == nudge.maxLevel;
 
-    q1ExpMs.isAvailable = theory.milestonesTotal > 3;
-    q3UnlockMs.isAvailable = theory.milestonesTotal > 3;
+    q1ExpMs.isAvailable = cooldownMs.level == cooldownMs.maxLevel &&
+    q1BorrowMs.level == q1BorrowMs.maxLevel;
+    q3UnlockMs.isAvailable = q1ExpMs.isAvailable;
     q3.isAvailable = q3UnlockMs.level > 0;
     marathonBadge = theory.achievements[1].isUnlocked;
 }
@@ -1019,7 +1022,7 @@ var tick = (elapsedTime, multiplier) =>
     nudge.isAutoBuyable = false;
     extraInc.isAutoBuyable = false;
 
-    if(freeze.level % 2 == 0)
+    if(nudge.level && freeze.level % 2 == 0)
     {
         time += elapsedTime * 10;
         let turned = false;
@@ -1074,7 +1077,7 @@ var tick = (elapsedTime, multiplier) =>
 
     currency.value += dt * tTerm * cSum.abs() * q1Term * q2Term * q3Term * bonus
     / rTerm;
-    EcCurrency.value = cSum;
+    // EcCurrency.value = cSum;
 }
 
 var getEquationOverlay = () =>
@@ -1148,7 +1151,7 @@ var getSecondaryEquation = () =>
     let EcStr = extraIncPerma.level > 0 && nudge.level == nudge.maxLevel ?
     '\\displaystyle\\frac{\\left|\\Sigma c\\right|}{2^{2r}}' :
     '\\left|\\sum c\\right|';
-    let result = `\\begin{matrix}\\dot{\\rho}=t\\times q_1
+    let result = `\\begin{matrix}\\dot{\\rho}=t{\\mkern 1mu}q_1
     ${q1ExpMs.level > 0 ?`^{${getq1Exponent(q1ExpMs.level)}}` : ''}q_2
     ${q3UnlockMs.level > 0 ? 'q_3' : ''}\\times${EcStr}\\\\\\\\
     ${theory.latexSymbol}=\\max{\\rho}^{0.1}\\end{matrix}`;
@@ -1158,19 +1161,14 @@ var getSecondaryEquation = () =>
 
 var getTertiaryEquation = () =>
 {
+    let tStr = `t=${turns}`;
     let cStr = '';
     if(historyNumMode & 2 || c > 1e9 || c < -1e8)
-        cStr = `,&c=${cBigNum < 0 ? '' : '+\\,'}${cBigNum.toString(0)}`;
-    return `\\begin{matrix}t=${turns}${cStr}\\end{matrix}`;
-
-    let tStr = `t=${turns},&`;
-    if(historyNumMode & 2 || c > 1e9 || c < -1e8)
-        cStr =  `\\\\(${cBigNum < 0 ? '' : '+\\,'}${cBigNum.toString(0)})`;
-
+        cStr = `,&c=${cBigNum.toString(0)}`;
     let csStr = `\\Sigma c=${cSum.toString(0)}`;
 
-    return `\\begin{array}{c}\\begin{matrix}${tStr}${csStr}\\end{matrix}
-    ${cStr}\\end{array}`;
+    return `\\begin{array}{c}\\begin{matrix}${tStr}${cStr}\\end{matrix}\\\\
+    ${csStr}\\end{array}`;
 }
 
 let createHistoryMenu = () =>

--- a/collatz.js
+++ b/collatz.js
@@ -1162,7 +1162,7 @@ var getTertiaryEquation = () =>
     let cStr = '';
     if(historyNumMode & 2 || c > 1e9 || c < -1e8)
         cStr = `,&${cBigNum < 0 ? '' : '+\\,'}${cBigNum.toString(0)}`;
-    return `begin{matrix}t=${turns}${cStr}`;
+    return `\\begin{matrix}t=${turns}${cStr}\\end{matrix}`;
 
     let tStr = `t=${turns},&`;
     if(historyNumMode & 2 || c > 1e9 || c < -1e8)

--- a/collatz.js
+++ b/collatz.js
@@ -144,7 +144,7 @@ const locStrings =
         history: 'History',
         historyDesc: `\\begin{{array}}{{c}}\\text{{History}}\\\\{{{0}}}/{{{1}}}
         \\end{{array}}`,
-        historyInfo: 'Shows the last and current publications\' sequences',
+        historyInfo: 'Shows the last and current sequences',
         freezeDesc: ['Freeze {0}', 'Unfreeze {0}'],
         freezeInfo:
         [
@@ -157,14 +157,14 @@ const locStrings =
         permaIncrementInfo: `Dependent on {0}'s sign; incurs penalty ` +
 `on overall income`,
         permaMimick: 'Auto-nudge {0}',
-        permaMimickInfo: 'Mimicks your last publication',
+        permaMimickInfo: 'Mimicks your last sequence',
 
         q1Level: 'q_1\\text{{ level}}',
         cLevel: '1/{{{0}}}\\text{{{{ of }}}}c\\text{{{{ level}}}}',
         cLevelth: `1/{{{0}}}^\\text{{{{th}}}}\\text{{{{ of }}}}c
         \\text{{{{ level}}}}`,
-        Eclog: `\\log_{{10}}\\Pi(\\Sigma c)\\text{{ (across pubs)}}`,
-        EclogInfo: 'Accumulates across publications (max {0})',
+        Eclog: `\\log_{{10}}\\Pi(\\Sigma c)\\text{{ across sequences}}`,
+        EclogInfo: 'Preserved after publications (max {0})',
         cLevelCap: 'c\\text{{ level cap}}',
         cooldown: '\\text{{interval}}',
         cooldownInfo: 'Interval',
@@ -317,10 +317,10 @@ Note: q1 levels have stopped stacking.`,
         permaBaseInfo: 'Changes the display of {0} on the equation',
 
         menuHistory: 'Sequence History',
-        labelCurrentRun: 'Current publication:',
-        labelLastRun: 'Last publication:',
+        labelCurrentRun: 'Current sequence:',
+        labelLastRun: 'Last sequence:',
         labelMimick: 'Auto-nudge {0} (follows last pub): ',
-        labelPreserve: 'Preserve last publication: ',
+        labelPreserve: 'Lock last sequence: ',
         errorInvalidNumMode: 'Invalid number mode',
         errorBinExpLimit: 'Too big',
 

--- a/collatz.js
+++ b/collatz.js
@@ -671,7 +671,7 @@ let binarySearch = (arr, target) =>
 var init = () =>
 {
     currency = theory.createCurrency();
-    EcCurrency = theory.createCurrency('Σc', '\\Sigma c');
+    EcCurrency = theory.createCurrency(' Σc', '\\Sigma c');
     /* Freeze
     Freeze c's value and the timer in place, which allows for idling. This will
     become more important later on, and also helps with farming c levels.
@@ -1161,7 +1161,7 @@ var getTertiaryEquation = () =>
 {
     let cStr = '';
     if(historyNumMode & 2 || c > 1e9 || c < -1e8)
-        cStr = `,&${cBigNum < 0 ? '' : '+\\,'}${cBigNum.toString(0)}`;
+        cStr = `,&c=${cBigNum < 0 ? '' : '+\\,'}${cBigNum.toString(0)}`;
     return `\\begin{matrix}t=${turns}${cStr}\\end{matrix}`;
 
     let tStr = `t=${turns},&`;

--- a/collatz.js
+++ b/collatz.js
@@ -144,14 +144,14 @@ const locStrings =
         historyDesc: `\\begin{{array}}{{c}}\\text{{History}}\\\\{{{0}}}/{{{1}}}
         \\end{{array}}`,
         historyInfo: `Shows the last and current publications' sequences`,
-        freezeDesc: ['Freeze {0}', 'Unfreeze {0}'],
+        freezeDesc: ['Freeze {0} timer', 'Unfreeze {0} timer'],
         freezeInfo:
         [
             'Freezes the turn timer in place',
             'Resumes the turn timer'
         ],
 
-        permaFreeze: '\\text{{the ability to freeze }}c',
+        permaFreeze: 'c \\text{{ timer freezing}}',
         permaIncrement: `\\text{{extra in/decrements for }}c`,
         permaIncrementInfo: `Dependent on {0}'s sign; incurs penalty ` +
 `on overall income`,

--- a/collatz.js
+++ b/collatz.js
@@ -88,12 +88,11 @@ const getq2 = (level) => BigNumber.TWO.pow(level);
 const q3Cost = new ExponentialCost(BigNumber.from('1e301'), Math.log2(1e3));
 const getq3 = (level) => BigNumber.THREE.pow(level) + (marathonBadge ? 1 : 0);
 
-const extraIncCost = new ExponentialCost(BigNumber.from('1e1250'),
-Math.log2(1e5));
+const extraIncCost = new ExponentialCost(1e40, Math.log2(5));
 const getr = (level) => Utils.getStepwisePowerSum(level, 2, 6, 0);
 const getrPenalty = (level) => BigNumber.FOUR.pow(getr(level));
 
-const permaCosts = bigNumArray(['1e12', '1e22', '1e27', '1e56', '1e1250',
+const permaCosts = bigNumArray(['1e12', '1e22', '1e27', '1e56', '1e1200',
 '1e100']);
 // 44, 88, 176, 264, 352, 440, 528, 616, 704
 // cap cap  cap  bor  q3  exp  exp  exp  exp
@@ -671,7 +670,7 @@ let binarySearch = (arr, target) =>
 var init = () =>
 {
     currency = theory.createCurrency();
-    EcCurrency = theory.createCurrency(' Σc', ' \\Sigma c');
+    EcCurrency = theory.createCurrency('Σc', '\\Sigma c');
     /* Freeze
     Freeze c's value and the timer in place, which allows for idling. This will
     become more important later on, and also helps with farming c levels.
@@ -784,7 +783,7 @@ var init = () =>
         let getDesc = (level) => `c\\leftarrow c
         ${c < 0n ? '-' : '+'}1;\\enspace r=${getr(level).toString(0)}`;
         let getInfo = (level) => `r=${getr(level).toString(0)}`;
-        extraInc = theory.createUpgrade(4, currency, extraIncCost);
+        extraInc = theory.createUpgrade(4, EcCurrency, extraIncCost);
         extraInc.getDescription = () => Utils.getMath(getDesc(
         extraInc.level));
         extraInc.getInfo = (amount) => Utils.getMathTo(getInfo(extraInc.level),

--- a/collatz.js
+++ b/collatz.js
@@ -144,7 +144,7 @@ const locStrings =
         history: 'History',
         historyDesc: `\\begin{{array}}{{c}}\\text{{History}}\\\\{{{0}}}/{{{1}}}
         \\end{{array}}`,
-        historyInfo: 'Shows the last and current sequences',
+        historyInfo: `Shows the last and current publications' sequences`,
         freezeDesc: ['Freeze {0}', 'Unfreeze {0}'],
         freezeInfo:
         [
@@ -163,7 +163,7 @@ const locStrings =
         cLevel: '1/{{{0}}}\\text{{{{ of }}}}c\\text{{{{ level}}}}',
         cLevelth: `1/{{{0}}}^\\text{{{{th}}}}\\text{{{{ of }}}}c
         \\text{{{{ level}}}}`,
-        Eclog: `\\log_{{10}}\\Pi(\\Sigma c)\\text{{ across sequences}}`,
+        Eclog: `\\log_{{10}}\\Pi(\\Sigma c)\\text{{ across publications}}`,
         EclogInfo: 'Preserved after publications (max {0})',
         cLevelCap: 'c\\text{{ level cap}}',
         cooldown: '\\text{{interval}}',
@@ -324,8 +324,8 @@ Note: q1 levels have stopped stacking.`,
         errorInvalidNumMode: 'Invalid number mode',
         errorBinExpLimit: 'Too big',
 
-        reset: `You are about to submit the current sequence.
-Everything except nudge polarity will be reset.`
+        reset: `You are about to restart the publication.
+Σc and nudge polarity will be preserved.`
     }
 };
 
@@ -1428,6 +1428,8 @@ var postPublish = () =>
     theory.invalidateSecondaryEquation();
     theory.invalidateTertiaryEquation();
     updateAvailability();
+
+    theory.clearGraph();
 }
 
 var canResetStage = () => true;
@@ -1443,10 +1445,27 @@ var resetStage = () =>
 
     currency.value = 0;
 
-    prePublish();
-    postPublish();
+    turns = 0;
+    time = 0;
+    // Disabling history write circumvents the extra levelling
+    writeHistory = false;
+    nudge.maxLevel = cLevelCap[cooldownMs.level];
+    nudge.level = 0;
+    writeHistory = true;
+    history = {};
+    // c is reset to 0 afterwards
 
-    theory.clearGraph();
+    c = 0n;
+    cBigNum = BigNumber.from(c);
+    cIterProgBar.progressTo(0, 220, Easing.CUBIC_INOUT);
+
+    if(mimickLastHistory)
+        nextNudge = binarySearch(Object.keys(lastHistory), turns);
+
+    theory.invalidatePrimaryEquation();
+    theory.invalidateSecondaryEquation();
+    theory.invalidateTertiaryEquation();
+    updateAvailability();
 }
 
 var getInternalState = () => JSON.stringify

--- a/collatz.js
+++ b/collatz.js
@@ -983,7 +983,7 @@ var init = () =>
 
     theory.primaryEquationHeight = 66;
     theory.primaryEquationScale = 0.9;
-    theory.secondaryEquationHeight = 48;
+    theory.secondaryEquationHeight = 52;
 }
 
 var updateAvailability = () =>


### PR DESCRIPTION
Balance changes!
- New milestone progression: 30, 45, 75, 105,... 
- Added a level of c cap milestone.
- Changed borrow milestone to log10 instead of log2.
  - Accumulation rate is also buffed.
QoL changes:
- Reworded many descriptions.
- Fixed 2nd equation clipping.
- Added cache for last history strings (may speed up loading).